### PR TITLE
Hide duplicate patch cards for unchanged session diffs

### DIFF
--- a/app/src/main/kotlin/dev/minios/ocremote/ui/screens/chat/ChatViewModel.kt
+++ b/app/src/main/kotlin/dev/minios/ocremote/ui/screens/chat/ChatViewModel.kt
@@ -273,12 +273,12 @@ class ChatViewModel @Inject constructor(
             } else {
                 sorted
             }
-            visible.map { msg ->
+            suppressRepeatedPatchCards(visible.map { msg ->
                 ChatMessage(
                     message = msg,
                     parts = allParts[msg.id] ?: emptyList()
                 )
-            }
+            })
         }
 
         // Resolve model: explicit selection > last user message's model > provider default

--- a/app/src/main/kotlin/dev/minios/ocremote/ui/screens/chat/PatchVisibilityResolver.kt
+++ b/app/src/main/kotlin/dev/minios/ocremote/ui/screens/chat/PatchVisibilityResolver.kt
@@ -1,0 +1,33 @@
+package dev.minios.ocremote.ui.screens.chat
+
+import dev.minios.ocremote.domain.model.Message
+import dev.minios.ocremote.domain.model.Part
+
+internal fun suppressRepeatedPatchCards(messages: List<ChatMessage>): List<ChatMessage> {
+    var lastVisiblePatchHash: String? = null
+
+    return messages.map { chatMessage ->
+        val assistantMessage = chatMessage.message as? Message.Assistant
+        if (assistantMessage == null) {
+            chatMessage
+        } else {
+            val filteredParts = buildList {
+                for (part in chatMessage.parts) {
+                    if (part is Part.Patch) {
+                        val normalizedHash = part.hash.trim()
+                        val isRepeatedPatch = normalizedHash.isNotEmpty() && normalizedHash == lastVisiblePatchHash
+                        if (!isRepeatedPatch) {
+                            add(part)
+                            if (normalizedHash.isNotEmpty()) {
+                                lastVisiblePatchHash = normalizedHash
+                            }
+                        }
+                    } else {
+                        add(part)
+                    }
+                }
+            }
+            chatMessage.copy(parts = filteredParts)
+        }
+    }
+}

--- a/app/src/test/kotlin/dev/minios/ocremote/ui/screens/chat/PatchVisibilityResolverTest.kt
+++ b/app/src/test/kotlin/dev/minios/ocremote/ui/screens/chat/PatchVisibilityResolverTest.kt
@@ -1,0 +1,128 @@
+package dev.minios.ocremote.ui.screens.chat
+
+import dev.minios.ocremote.domain.model.Message
+import dev.minios.ocremote.domain.model.Part
+import dev.minios.ocremote.domain.model.TimeInfo
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class PatchVisibilityResolverTest {
+
+    @Test
+    fun suppressRepeatedPatchCards_hidesRepeatedNonBlankHashAcrossAssistantMessages() {
+        val firstPatch = patchPart(messageId = "assistant-1", partId = "patch-1", hash = "same-hash")
+        val secondPatch = patchPart(messageId = "assistant-2", partId = "patch-2", hash = "same-hash")
+
+        val messages = listOf(
+            assistantMessage(id = "assistant-1", parts = listOf(firstPatch)),
+            assistantMessage(id = "assistant-2", parts = listOf(secondPatch)),
+        )
+
+        val visible = suppressRepeatedPatchCards(messages)
+
+        assertEquals(listOf(firstPatch), visible[0].parts.filterIsInstance<Part.Patch>())
+        assertTrue(visible[1].parts.filterIsInstance<Part.Patch>().isEmpty())
+    }
+
+    @Test
+    fun suppressRepeatedPatchCards_keepsPatchWhenHashChanges() {
+        val firstPatch = patchPart(messageId = "assistant-1", partId = "patch-1", hash = "hash-1")
+        val secondPatch = patchPart(messageId = "assistant-2", partId = "patch-2", hash = "hash-2")
+
+        val messages = listOf(
+            assistantMessage(id = "assistant-1", parts = listOf(firstPatch)),
+            assistantMessage(id = "assistant-2", parts = listOf(secondPatch)),
+        )
+
+        val visible = suppressRepeatedPatchCards(messages)
+
+        assertEquals(listOf(firstPatch), visible[0].parts.filterIsInstance<Part.Patch>())
+        assertEquals(listOf(secondPatch), visible[1].parts.filterIsInstance<Part.Patch>())
+    }
+
+    @Test
+    fun suppressRepeatedPatchCards_doesNotResetForNonPatchAssistantParts() {
+        val firstPatch = patchPart(messageId = "assistant-1", partId = "patch-1", hash = "same-hash")
+        val textOnly = textPart(messageId = "assistant-2", partId = "text-1", text = "daily report")
+        val repeatedPatch = patchPart(messageId = "assistant-3", partId = "patch-2", hash = "same-hash")
+
+        val messages = listOf(
+            assistantMessage(id = "assistant-1", parts = listOf(firstPatch)),
+            assistantMessage(id = "assistant-2", parts = listOf(textOnly)),
+            assistantMessage(id = "assistant-3", parts = listOf(repeatedPatch)),
+        )
+
+        val visible = suppressRepeatedPatchCards(messages)
+
+        assertEquals(listOf(firstPatch), visible[0].parts.filterIsInstance<Part.Patch>())
+        assertEquals(listOf(textOnly), visible[1].parts.filterIsInstance<Part.Text>())
+        assertTrue(visible[2].parts.filterIsInstance<Part.Patch>().isEmpty())
+    }
+
+    @Test
+    fun suppressRepeatedPatchCards_keepsRepeatedHashAfterDifferentHash() {
+        val firstPatch = patchPart(messageId = "assistant-1", partId = "patch-1", hash = "hash-a")
+        val secondPatch = patchPart(messageId = "assistant-2", partId = "patch-2", hash = "hash-b")
+        val thirdPatch = patchPart(messageId = "assistant-3", partId = "patch-3", hash = "hash-a")
+
+        val messages = listOf(
+            assistantMessage(id = "assistant-1", parts = listOf(firstPatch)),
+            assistantMessage(id = "assistant-2", parts = listOf(secondPatch)),
+            assistantMessage(id = "assistant-3", parts = listOf(thirdPatch)),
+        )
+
+        val visible = suppressRepeatedPatchCards(messages)
+
+        assertEquals(listOf(firstPatch), visible[0].parts.filterIsInstance<Part.Patch>())
+        assertEquals(listOf(secondPatch), visible[1].parts.filterIsInstance<Part.Patch>())
+        assertEquals(listOf(thirdPatch), visible[2].parts.filterIsInstance<Part.Patch>())
+    }
+
+    @Test
+    fun suppressRepeatedPatchCards_keepsBlankHashPatchVisible() {
+        val firstPatch = patchPart(messageId = "assistant-1", partId = "patch-1", hash = "")
+        val secondPatch = patchPart(messageId = "assistant-2", partId = "patch-2", hash = "")
+
+        val messages = listOf(
+            assistantMessage(id = "assistant-1", parts = listOf(firstPatch)),
+            assistantMessage(id = "assistant-2", parts = listOf(secondPatch)),
+        )
+
+        val visible = suppressRepeatedPatchCards(messages)
+
+        assertEquals(listOf(firstPatch), visible[0].parts.filterIsInstance<Part.Patch>())
+        assertEquals(listOf(secondPatch), visible[1].parts.filterIsInstance<Part.Patch>())
+    }
+
+    private fun assistantMessage(id: String, parts: List<Part>): ChatMessage {
+        return ChatMessage(
+            message = Message.Assistant(
+                id = id,
+                sessionId = "session-1",
+                time = TimeInfo(created = 1L),
+                parentId = "parent-$id",
+            ),
+            parts = parts,
+        )
+    }
+
+    private fun patchPart(messageId: String, partId: String, hash: String): Part.Patch {
+        return Part.Patch(
+            id = partId,
+            sessionId = "session-1",
+            messageId = messageId,
+            hash = hash,
+            files = listOf("README.md"),
+        )
+    }
+
+    private fun textPart(messageId: String, partId: String, text: String): Part.Text {
+        return Part.Text(
+            id = partId,
+            sessionId = "session-1",
+            messageId = messageId,
+            text = text,
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- collapse consecutive assistant patch cards when the server reports the same non-blank patch hash repeatedly
- keep patch cards visible when the hash changes or is blank, so real state transitions still surface in chat
- add regression tests for repeated, changed, intervening text, and blank-hash patch sequences

## Verification
- ./gradlew testDebugUnitTest
- ./gradlew assembleDebug
- Installed the debug APK on the Pixel emulator and confirmed the app launches to the OC Remote home screen