### PR TITLE
fix(chat): keep new user messages visible during initial load

### DIFF
--- a/app/src/main/kotlin/dev/minios/ocremote/ui/screens/chat/ChatViewModel.kt
+++ b/app/src/main/kotlin/dev/minios/ocremote/ui/screens/chat/ChatViewModel.kt
@@ -262,8 +262,9 @@ class ChatViewModel @Inject constructor(
         // While the REST call is still loading, suppress SSE-only messages to prevent
         // showing a flash of partial data (e.g., 1-2 messages from SSE when opening via
         // notification deep-link before the full history arrives).
-        val chatMessages = if (loading && sessionMessages.size < 3) {
-            // Likely only SSE-provided messages; wait for REST to complete
+        val hasUserMessage = sessionMessages.any { it is Message.User }
+        val shouldSuppressPartialData = loading && sessionMessages.size < 3 && !hasUserMessage
+        val chatMessages = if (shouldSuppressPartialData) {
             emptyList()
         } else {
             val sorted = sessionMessages.sortedBy { it.time.created }


### PR DESCRIPTION
## Summary
- Keep SSE-delivered user messages visible while the initial session history is still loading.
- Narrow the partial-data suppression rule so it only hides early SSE payloads before any user message has arrived.

## Verification
- Reviewed the isolated single-file diff against `upstream/master`.
- Confirmed the branch only contains `app/src/main/kotlin/dev/minios/ocremote/ui/screens/chat/ChatViewModel.kt`.
- Gradle verification could not be run in this environment because no Java runtime is installed.

## Screenshots
- Not applicable for this PR. The change only adjusts timing/visibility during initial loading and does not introduce a new UI surface that a static screenshot would meaningfully review.