### PR TITLE
fix(chat): keep user messages visible during initial load

### DIFF
--- a/app/src/main/kotlin/dev/minios/ocremote/ui/screens/chat/ChatViewModel.kt
+++ b/app/src/main/kotlin/dev/minios/ocremote/ui/screens/chat/ChatViewModel.kt
@@ -262,8 +262,9 @@ class ChatViewModel @Inject constructor(
         // While the REST call is still loading, suppress SSE-only messages to prevent
         // showing a flash of partial data (e.g., 1-2 messages from SSE when opening via
         // notification deep-link before the full history arrives).
-        val chatMessages = if (loading && sessionMessages.size < 3) {
-            // Likely only SSE-provided messages; wait for REST to complete
+        val hasUserMessage = sessionMessages.any { it is Message.User }
+        val shouldSuppressPartialData = loading && sessionMessages.size < 3 && !hasUserMessage
+        val chatMessages = if (shouldSuppressPartialData) {
             emptyList()
         } else {
             val sorted = sessionMessages.sortedBy { it.time.created }


### PR DESCRIPTION
## Summary
- keep user messages visible while the initial REST history load is still in progress
- preserve the existing partial-data guard for deep-link/session-open flows that only have early SSE data

## Problem
When a session was still loading its initial history, the chat screen suppressed small message lists to avoid flashing incomplete SSE-only data. That suppression also hid legitimate user messages that arrived early, so a newly sent message could appear to vanish until loading finished.

## Fix
- detect whether the current session message list already contains a `Message.User`
- only suppress partial data when the list is small and there is no user message yet

## Verification
- built the debug APK successfully in a clean worktree with only this patch applied

## Screenshots
- not attached because this is a timing-sensitive visibility fix during initial loading rather than a stable new UI surface