### PR TITLE
fix(home): keep server settings available for custom providers

### DIFF
--- a/app/src/main/kotlin/dev/minios/ocremote/ui/screens/home/HomeViewModel.kt
+++ b/app/src/main/kotlin/dev/minios/ocremote/ui/screens/home/HomeViewModel.kt
@@ -14,6 +14,8 @@ import dev.minios.ocremote.R
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
 import dev.minios.ocremote.data.api.OpenCodeApi
+import dev.minios.ocremote.data.api.ProviderCatalogResponse
+import dev.minios.ocremote.data.api.ProvidersResponse
 import dev.minios.ocremote.data.api.ServerConnection
 import dev.minios.ocremote.data.repository.LocalServerManager
 import dev.minios.ocremote.data.repository.ServerRepository
@@ -33,6 +35,24 @@ import javax.inject.Inject
 
 private const val TAG = "HomeViewModel"
 private const val LOCAL_SERVER_NAME = "Local OpenCode"
+
+internal fun hasServerSettingsAccess(
+    providersResponse: ProvidersResponse,
+    providerCatalog: ProviderCatalogResponse? = null,
+): Boolean {
+    if (providersResponse.providers.isNotEmpty()) {
+        return true
+    }
+    if (providersResponse.default.isNotEmpty()) {
+        return true
+    }
+    if (providerCatalog == null) {
+        return false
+    }
+    return providerCatalog.all.isNotEmpty() ||
+        providerCatalog.connected.isNotEmpty() ||
+        providerCatalog.default.isNotEmpty()
+}
 
 enum class LocalRuntimeStatus {
     Unavailable,
@@ -251,11 +271,18 @@ class HomeViewModel @Inject constructor(
 
                 try {
                     val conn = ServerConnection.from(server.url, server.username, server.password)
-                    val response = api.getProviders(conn)
-                    val hasModels = response.providers.any { it.models.isNotEmpty() }
+                    val providersResponse = api.getProviders(conn)
+                    val providerCatalog = runCatching { api.listProviderCatalog(conn) }
+                        .getOrElse { error ->
+                            if (BuildConfig.DEBUG) {
+                                Log.d(TAG, "Provider catalog check failed for $serverId: ${error.message}")
+                            }
+                            null
+                        }
+                    val hasSettingsAccess = hasServerSettingsAccess(providersResponse, providerCatalog)
                     _uiState.update {
                         it.copy(
-                            serverSettingsReadyIds = if (hasModels) {
+                            serverSettingsReadyIds = if (hasSettingsAccess) {
                                 it.serverSettingsReadyIds + serverId
                             } else {
                                 it.serverSettingsReadyIds - serverId

--- a/app/src/test/kotlin/dev/minios/ocremote/ui/screens/home/HomeViewModelTest.kt
+++ b/app/src/test/kotlin/dev/minios/ocremote/ui/screens/home/HomeViewModelTest.kt
@@ -1,0 +1,89 @@
+package dev.minios.ocremote.ui.screens.home
+
+import dev.minios.ocremote.data.api.ProviderCatalogResponse
+import dev.minios.ocremote.data.api.ProviderInfo
+import dev.minios.ocremote.data.api.ProviderModel
+import dev.minios.ocremote.data.api.ProvidersResponse
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class HomeViewModelTest {
+
+    @Test
+    fun `returns true when provider response already has models`() {
+        val response = ProvidersResponse(
+            providers = listOf(
+                providerInfo(
+                    id = "openai",
+                    name = "OpenAI",
+                    models = mapOf(
+                        "gpt-5" to providerModel("gpt-5", "GPT-5")
+                    )
+                )
+            )
+        )
+
+        assertTrue(hasServerSettingsAccess(response))
+    }
+
+    @Test
+    fun `returns true when custom provider exists without published models`() {
+        val response = ProvidersResponse(
+            providers = listOf(
+                providerInfo(
+                    id = "openai-compatible",
+                    name = "OpenAI Compatible",
+                    source = "custom",
+                )
+            )
+        )
+
+        assertTrue(hasServerSettingsAccess(response))
+    }
+
+    @Test
+    fun `returns true when provider catalog exposes custom provider after config providers are empty`() {
+        val response = ProvidersResponse(providers = emptyList())
+        val catalog = ProviderCatalogResponse(
+            all = listOf(
+                providerInfo(
+                    id = "openai-compatible",
+                    name = "OpenAI Compatible",
+                    source = "custom",
+                )
+            ),
+            connected = listOf("openai-compatible")
+        )
+
+        assertTrue(hasServerSettingsAccess(response, catalog))
+    }
+
+    @Test
+    fun `returns false when neither providers response nor catalog expose settings data`() {
+        assertFalse(
+            hasServerSettingsAccess(
+                ProvidersResponse(providers = emptyList()),
+                ProviderCatalogResponse(all = emptyList())
+            )
+        )
+    }
+
+    private fun providerInfo(
+        id: String,
+        name: String,
+        source: String = "",
+        models: Map<String, ProviderModel> = emptyMap(),
+    ) = ProviderInfo(
+        id = id,
+        name = name,
+        source = source,
+        models = models,
+    )
+
+    private fun providerModel(id: String, name: String) = ProviderModel(
+        id = id,
+        providerId = "",
+        name = name,
+    )
+}


### PR DESCRIPTION
## Summary
- keep the home screen server settings entry available when a connected custom provider has no published model list yet
- fall back to provider catalog availability instead of requiring non-empty provider models
- add a regression test for custom providers without published models

## Verification
- ./gradlew testDebugUnitTest --tests \"dev.minios.ocremote.ui.screens.home.HomeViewModelTest\"
- ./gradlew assembleDebug
- mobile MCP smoke test on emulator-5554