### PR TITLE
fix(session-list): preserve busy status for new sessions

### DIFF
--- a/app/src/main/kotlin/dev/minios/ocremote/data/repository/EventReducer.kt
+++ b/app/src/main/kotlin/dev/minios/ocremote/data/repository/EventReducer.kt
@@ -123,7 +123,9 @@ class EventReducer @Inject constructor() {
         _sessions.update { current ->
             (current + event.info).sortedByDescending { it.time.updated }
         }
-        _sessionStatuses.update { it + (event.info.id to SessionStatus.Idle) }
+        _sessionStatuses.update { current ->
+            if (event.info.id in current) current else current + (event.info.id to SessionStatus.Idle)
+        }
     }
     
     private fun handleSessionUpdated(event: SseEvent.SessionUpdated, serverId: String) {

--- a/app/src/main/kotlin/dev/minios/ocremote/data/repository/EventReducer.kt
+++ b/app/src/main/kotlin/dev/minios/ocremote/data/repository/EventReducer.kt
@@ -79,8 +79,8 @@ class EventReducer @Inject constructor() {
             is SseEvent.SessionCreated -> handleSessionCreated(event, serverId)
             is SseEvent.SessionUpdated -> handleSessionUpdated(event, serverId)
             is SseEvent.SessionDeleted -> handleSessionDeleted(event)
-            is SseEvent.SessionStatus -> handleSessionStatus(event)
-            is SseEvent.SessionIdle -> handleSessionIdle(event)
+            is SseEvent.SessionStatus -> handleSessionStatus(event, serverId)
+            is SseEvent.SessionIdle -> handleSessionIdle(event, serverId)
             is SseEvent.SessionDiff -> handleSessionDiff(event)
             is SseEvent.SessionError -> handleSessionError(event)
             
@@ -161,12 +161,14 @@ class EventReducer @Inject constructor() {
         _questions.update { it - sessionId }
     }
     
-    private fun handleSessionStatus(event: SseEvent.SessionStatus) {
+    private fun handleSessionStatus(event: SseEvent.SessionStatus, serverId: String) {
+        trackSession(serverId, event.sessionId)
         _sessionStatuses.update { it + (event.sessionId to event.status) }
         if (BuildConfig.DEBUG) Log.d(TAG, "Session ${event.sessionId} status: ${event.status}")
     }
     
-    private fun handleSessionIdle(event: SseEvent.SessionIdle) {
+    private fun handleSessionIdle(event: SseEvent.SessionIdle, serverId: String) {
+        trackSession(serverId, event.sessionId)
         _sessionStatuses.update { it + (event.sessionId to SessionStatus.Idle) }
     }
     
@@ -412,8 +414,6 @@ class EventReducer @Inject constructor() {
             return
         }
         
-        if (BuildConfig.DEBUG) Log.d(TAG, "Clearing state for server $serverId (${sessionIds.size} sessions)")
-        
         // Remove the server's session tracking
         _serverSessions.update { it - serverId }
         
@@ -434,6 +434,8 @@ class EventReducer @Inject constructor() {
             .toSet()
         _messages.update { it - sessionIds }
         _parts.update { it - messageIds }
+
+        if (BuildConfig.DEBUG) Log.d(TAG, "Clearing state for server $serverId (${sessionIds.size} sessions)")
     }
     
     // ============ Todo Events ============

--- a/app/src/test/kotlin/dev/minios/ocremote/data/repository/EventReducerTest.kt
+++ b/app/src/test/kotlin/dev/minios/ocremote/data/repository/EventReducerTest.kt
@@ -3,8 +3,8 @@ package dev.minios.ocremote.data.repository
 import dev.minios.ocremote.domain.model.Session
 import dev.minios.ocremote.domain.model.SessionStatus
 import dev.minios.ocremote.domain.model.SseEvent
-import kotlinx.coroutines.flow.MutableStateFlow
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
 import org.junit.Test
 
 class EventReducerTest {
@@ -14,7 +14,7 @@ class EventReducerTest {
         val reducer = EventReducer()
         val session = testSession(id = "ses_new")
 
-        setSessionStatuses(reducer, mapOf(session.id to SessionStatus.Busy))
+        processStatusEvent(reducer, session.id, SessionStatus.Busy, serverId = "server-1")
         reducer.processEvent(SseEvent.SessionCreated(session), serverId = "server-1")
 
         assertEquals(SessionStatus.Busy, reducer.sessionStatuses.value[session.id])
@@ -30,6 +30,43 @@ class EventReducerTest {
         assertEquals(SessionStatus.Idle, reducer.sessionStatuses.value[session.id])
     }
 
+    @Test
+    fun statusBeforeSessionCreatedIsClearedOnDisconnect() {
+        val reducer = EventReducer()
+        val session = testSession(id = "ses_new")
+
+        processStatusEvent(reducer, session.id, SessionStatus.Busy, serverId = "server-1")
+
+        clearForServer(reducer, "server-1")
+
+        assertNull(reducer.sessionStatuses.value[session.id])
+    }
+
+    @Test
+    fun clearedStatusDoesNotLeakIntoReconnectedSession() {
+        val reducer = EventReducer()
+        val session = testSession(id = "ses_new")
+
+        processStatusEvent(reducer, session.id, SessionStatus.Busy, serverId = "server-1")
+
+        clearForServer(reducer, "server-1")
+        reducer.processEvent(SseEvent.SessionCreated(session), serverId = "server-1")
+
+        assertEquals(SessionStatus.Idle, reducer.sessionStatuses.value[session.id])
+    }
+
+    @Test
+    fun sessionIdleBeforeSessionCreatedIsClearedOnDisconnect() {
+        val reducer = EventReducer()
+        val session = testSession(id = "ses_new")
+
+        reducer.processEvent(SseEvent.SessionIdle(sessionId = session.id), serverId = "server-1")
+
+        clearForServer(reducer, "server-1")
+
+        assertNull(reducer.sessionStatuses.value[session.id])
+    }
+
     private fun testSession(id: String) = Session(
         id = id,
         directory = "/tmp/project",
@@ -39,11 +76,31 @@ class EventReducerTest {
         ),
     )
 
-    @Suppress("UNCHECKED_CAST")
-    private fun setSessionStatuses(reducer: EventReducer, statuses: Map<String, SessionStatus>) {
-        val field = EventReducer::class.java.getDeclaredField("_sessionStatuses")
-        field.isAccessible = true
-        val stateFlow = field.get(reducer) as MutableStateFlow<Map<String, SessionStatus>>
-        stateFlow.value = statuses
+    private fun processStatusEvent(
+        reducer: EventReducer,
+        sessionId: String,
+        status: SessionStatus,
+        serverId: String,
+    ) {
+        try {
+            reducer.processEvent(
+                SseEvent.SessionStatus(sessionId = sessionId, status = status),
+                serverId = serverId
+            )
+        } catch (error: RuntimeException) {
+            if (!error.message.orEmpty().contains("android.util.Log not mocked")) {
+                throw error
+            }
+        }
+    }
+
+    private fun clearForServer(reducer: EventReducer, serverId: String) {
+        try {
+            reducer.clearForServer(serverId)
+        } catch (error: RuntimeException) {
+            if (!error.message.orEmpty().contains("android.util.Log not mocked")) {
+                throw error
+            }
+        }
     }
 }

--- a/app/src/test/kotlin/dev/minios/ocremote/data/repository/EventReducerTest.kt
+++ b/app/src/test/kotlin/dev/minios/ocremote/data/repository/EventReducerTest.kt
@@ -1,0 +1,49 @@
+package dev.minios.ocremote.data.repository
+
+import dev.minios.ocremote.domain.model.Session
+import dev.minios.ocremote.domain.model.SessionStatus
+import dev.minios.ocremote.domain.model.SseEvent
+import kotlinx.coroutines.flow.MutableStateFlow
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class EventReducerTest {
+
+    @Test
+    fun sessionCreatedPreservesExistingBusyStatus() {
+        val reducer = EventReducer()
+        val session = testSession(id = "ses_new")
+
+        setSessionStatuses(reducer, mapOf(session.id to SessionStatus.Busy))
+        reducer.processEvent(SseEvent.SessionCreated(session), serverId = "server-1")
+
+        assertEquals(SessionStatus.Busy, reducer.sessionStatuses.value[session.id])
+    }
+
+    @Test
+    fun sessionCreatedInitializesMissingStatusToIdle() {
+        val reducer = EventReducer()
+        val session = testSession(id = "ses_new")
+
+        reducer.processEvent(SseEvent.SessionCreated(session), serverId = "server-1")
+
+        assertEquals(SessionStatus.Idle, reducer.sessionStatuses.value[session.id])
+    }
+
+    private fun testSession(id: String) = Session(
+        id = id,
+        directory = "/tmp/project",
+        time = Session.Time(
+            created = 1L,
+            updated = 1L,
+        ),
+    )
+
+    @Suppress("UNCHECKED_CAST")
+    private fun setSessionStatuses(reducer: EventReducer, statuses: Map<String, SessionStatus>) {
+        val field = EventReducer::class.java.getDeclaredField("_sessionStatuses")
+        field.isAccessible = true
+        val stateFlow = field.get(reducer) as MutableStateFlow<Map<String, SessionStatus>>
+        stateFlow.value = statuses
+    }
+}


### PR DESCRIPTION
## Summary
- preserve an existing session status when `session.created` arrives after processing has already started
- track status-first and idle-first sessions so disconnect cleanup removes stale statuses instead of leaking them into reconnects
- add regression tests covering busy preservation, disconnect cleanup, and reconnect initialization for new sessions

## Verification
- `./gradlew testDebugUnitTest --tests "dev.minios.ocremote.data.repository.EventReducerTest"`
- `./gradlew assembleDebug`

## Notes
- No screenshot is attached because the current CLI environment cannot upload image assets directly.