### PR TITLE
feat: allow self-signed certificates per server

### DIFF
--- a/app/src/main/kotlin/dev/minios/ocremote/MainActivity.kt
+++ b/app/src/main/kotlin/dev/minios/ocremote/MainActivity.kt
@@ -65,7 +65,8 @@ data class SessionDeepLink(
     val password: String,
     val serverName: String,
     val sessionPath: String,  // e.g. /L2hvbWUv.../session/abc123
-    val sessionId: String = "" // raw session ID (fallback when sessionPath is empty)
+    val sessionId: String = "", // raw session ID (fallback when sessionPath is empty)
+    val allowSelfSigned: Boolean = false,
 )
 
 /**
@@ -250,6 +251,7 @@ class MainActivity : ComponentActivity() {
                     putExtra("server_url", savedServer.url)
                     putExtra("server_username", savedServer.username)
                     putExtra("server_password", savedServer.password)
+                    putExtra("server_allow_self_signed", savedServer.allowSelfSigned)
                 }
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
                     startForegroundService(serviceIntent)
@@ -270,6 +272,7 @@ class MainActivity : ComponentActivity() {
                     serverName = savedServer?.displayName ?: serverName,
                     sessionPath = sessionPath,
                     sessionId = sessionId,
+                    allowSelfSigned = savedServer?.allowSelfSigned ?: false,
                 )
             )
         }

--- a/app/src/main/kotlin/dev/minios/ocremote/core/network/InsecureTls.kt
+++ b/app/src/main/kotlin/dev/minios/ocremote/core/network/InsecureTls.kt
@@ -1,0 +1,44 @@
+package dev.minios.ocremote.core.network
+
+import java.security.SecureRandom
+import java.security.cert.X509Certificate
+import javax.net.ssl.SSLContext
+import javax.net.ssl.SSLSocketFactory
+import javax.net.ssl.TrustManager
+import javax.net.ssl.X509TrustManager
+
+/**
+ * TLS configuration that accepts any certificate and any hostname.
+ *
+ * Used only for servers that explicitly opt in via the
+ * "Allow self-signed certificates" toggle in the server dialog.
+ * Never use this for servers you do not fully trust.
+ */
+object InsecureTls {
+
+    /**
+     * Trust-all [X509TrustManager]. Accepts every certificate chain.
+     */
+    val trustAllManager: X509TrustManager = object : X509TrustManager {
+        override fun checkClientTrusted(chain: Array<out X509Certificate>?, authType: String?) = Unit
+        override fun checkServerTrusted(chain: Array<out X509Certificate>?, authType: String?) = Unit
+        override fun getAcceptedIssuers(): Array<X509Certificate> = arrayOf()
+    }
+
+    /**
+     * An [SSLSocketFactory] that trusts every certificate.
+     */
+    fun createSslSocketFactory(): SSLSocketFactory {
+        val sslContext = SSLContext.getInstance("TLS")
+        sslContext.init(null, arrayOf<TrustManager>(trustAllManager), SecureRandom())
+        return sslContext.socketFactory
+    }
+
+    /**
+     * Apply trust-all configuration to an [okhttp3.OkHttpClient.Builder].
+     */
+    fun applyToOkHttp(builder: okhttp3.OkHttpClient.Builder) {
+        builder.sslSocketFactory(createSslSocketFactory(), trustAllManager)
+        builder.hostnameVerifier { _, _ -> true }
+    }
+}

--- a/app/src/main/kotlin/dev/minios/ocremote/data/api/OpenCodeApi.kt
+++ b/app/src/main/kotlin/dev/minios/ocremote/data/api/OpenCodeApi.kt
@@ -28,6 +28,7 @@ import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import java.util.Base64
 import javax.inject.Inject
+import javax.inject.Named
 import javax.inject.Singleton
 
 /**
@@ -36,10 +37,16 @@ import javax.inject.Singleton
  */
 data class ServerConnection(
     val baseUrl: String,
-    val authHeader: String?
+    val authHeader: String?,
+    val allowSelfSigned: Boolean = false,
 ) {
     companion object {
-        fun from(url: String, username: String = "opencode", password: String? = null): ServerConnection {
+        fun from(
+            url: String,
+            username: String = "opencode",
+            password: String? = null,
+            allowSelfSigned: Boolean = false,
+        ): ServerConnection {
             val base = url.trimEnd('/')
             val auth = if (password != null) {
                 val credentials = "$username:$password"
@@ -47,7 +54,7 @@ data class ServerConnection(
             } else {
                 null
             }
-            return ServerConnection(base, auth)
+            return ServerConnection(base, auth, allowSelfSigned)
         }
     }
 }
@@ -70,9 +77,17 @@ internal fun healthStatusException(statusCode: Int): Exception? = when (statusCo
  */
 @Singleton
 class OpenCodeApi @Inject constructor(
-    private val httpClient: HttpClient,
+    @Named("secure") private val httpClient: HttpClient,
+    @Named("insecure") private val insecureHttpClient: HttpClient,
     private val json: Json
 ) {
+
+    /**
+     * Pick the HTTP client matching the server's TLS preference.
+     * [ServerConnection.allowSelfSigned] selects the trust-all client.
+     */
+    private fun clientFor(conn: ServerConnection): HttpClient =
+        if (conn.allowSelfSigned) insecureHttpClient else httpClient
     companion object {
         private const val TAG = "OpenCodeApi"
     }
@@ -80,7 +95,7 @@ class OpenCodeApi @Inject constructor(
     // ============ Global ============
 
     suspend fun getHealth(conn: ServerConnection): ServerHealth {
-        val response = httpClient.get("${conn.baseUrl}/global/health") {
+        val response = clientFor(conn).get("${conn.baseUrl}/global/health") {
             conn.authHeader?.let { header("Authorization", it) }
         }
         healthStatusException(response.status.value)?.let { throw it }
@@ -92,7 +107,7 @@ class OpenCodeApi @Inject constructor(
      * GET /path
      */
     suspend fun getServerPaths(conn: ServerConnection): ServerPaths {
-        return httpClient.get("${conn.baseUrl}/path") {
+        return clientFor(conn).get("${conn.baseUrl}/path") {
             conn.authHeader?.let { header("Authorization", it) }
         }.body()
     }
@@ -100,7 +115,7 @@ class OpenCodeApi @Inject constructor(
     // ============ Project ============
 
     suspend fun listProjects(conn: ServerConnection): List<Project> {
-        return httpClient.get("${conn.baseUrl}/project") {
+        return clientFor(conn).get("${conn.baseUrl}/project") {
             conn.authHeader?.let { header("Authorization", it) }
         }.body()
     }
@@ -110,7 +125,7 @@ class OpenCodeApi @Inject constructor(
         projectId: String,
         directory: String? = null,
         workspaceId: String? = null,
-    ): List<ProjectDirectory> = httpClient.get("${conn.baseUrl}/project/$projectId/directories") {
+    ): List<ProjectDirectory> = clientFor(conn).get("${conn.baseUrl}/project/$projectId/directories") {
         conn.authHeader?.let { header("Authorization", it) }
         directory?.let { parameter("directory", it) }
         workspaceId?.let { parameter("workspace", it) }
@@ -120,14 +135,14 @@ class OpenCodeApi @Inject constructor(
         conn: ServerConnection,
         directory: String,
         workspaceId: String? = null,
-    ): List<WorkspaceInfo> = httpClient.get("${conn.baseUrl}/experimental/workspace") {
+    ): List<WorkspaceInfo> = clientFor(conn).get("${conn.baseUrl}/experimental/workspace") {
         conn.authHeader?.let { header("Authorization", it) }
         parameter("directory", directory)
         workspaceId?.let { parameter("workspace", it) }
     }.body()
 
     suspend fun getCurrentProject(conn: ServerConnection): Project {
-        return httpClient.get("${conn.baseUrl}/project/current") {
+        return clientFor(conn).get("${conn.baseUrl}/project/current") {
             conn.authHeader?.let { header("Authorization", it) }
         }.body()
     }
@@ -140,7 +155,7 @@ class OpenCodeApi @Inject constructor(
      * Returns agents filtered to primary/visible ones for the mode selector.
      */
     suspend fun listAgents(conn: ServerConnection): List<AgentInfo> {
-        return httpClient.get("${conn.baseUrl}/agent") {
+        return clientFor(conn).get("${conn.baseUrl}/agent") {
             conn.authHeader?.let { header("Authorization", it) }
         }.body()
     }
@@ -148,7 +163,7 @@ class OpenCodeApi @Inject constructor(
     // ============ Session ============
 
     suspend fun listSessions(conn: ServerConnection, directory: String? = null): List<Session> {
-        return httpClient.get("${conn.baseUrl}/session") {
+        return clientFor(conn).get("${conn.baseUrl}/session") {
             conn.authHeader?.let { header("Authorization", it) }
             directory?.let { header("x-opencode-directory", it) }
             parameter("roots", "true")
@@ -159,7 +174,7 @@ class OpenCodeApi @Inject constructor(
         conn: ServerConnection,
         directory: String? = null,
     ): Map<String, SessionStatus> {
-        val payload: JsonObject = httpClient.get("${conn.baseUrl}/session/status") {
+        val payload: JsonObject = clientFor(conn).get("${conn.baseUrl}/session/status") {
             conn.authHeader?.let { header("Authorization", it) }
             directory?.let { header("x-opencode-directory", it) }
         }.body()
@@ -178,7 +193,7 @@ class OpenCodeApi @Inject constructor(
     }
 
     suspend fun getSession(conn: ServerConnection, sessionId: String, directory: String? = null): Session {
-        return httpClient.get("${conn.baseUrl}/session/$sessionId") {
+        return clientFor(conn).get("${conn.baseUrl}/session/$sessionId") {
             conn.authHeader?.let { header("Authorization", it) }
             directory?.let { header("x-opencode-directory", it) }
         }.body()
@@ -189,7 +204,7 @@ class OpenCodeApi @Inject constructor(
         sessionId: String,
         directory: String? = null,
     ): List<Session> {
-        return httpClient.get("${conn.baseUrl}/session/$sessionId/children") {
+        return clientFor(conn).get("${conn.baseUrl}/session/$sessionId/children") {
             conn.authHeader?.let { header("Authorization", it) }
             directory?.let { header("x-opencode-directory", it) }
         }.body()
@@ -197,7 +212,7 @@ class OpenCodeApi @Inject constructor(
 
     /** Returns session info as raw JSON string (for export without re-serialization). */
     suspend fun getSessionRaw(conn: ServerConnection, sessionId: String): String {
-        return httpClient.get("${conn.baseUrl}/session/$sessionId") {
+        return clientFor(conn).get("${conn.baseUrl}/session/$sessionId") {
             conn.authHeader?.let { header("Authorization", it) }
         }.bodyAsText()
     }
@@ -207,7 +222,7 @@ class OpenCodeApi @Inject constructor(
             title?.let { put("title", it) }
             parentId?.let { put("parentID", it) }
         }
-        return httpClient.post("${conn.baseUrl}/session") {
+        return clientFor(conn).post("${conn.baseUrl}/session") {
             conn.authHeader?.let { header("Authorization", it) }
             directory?.let { header("x-opencode-directory", it) }
             contentType(ContentType.Application.Json)
@@ -216,14 +231,14 @@ class OpenCodeApi @Inject constructor(
     }
 
     suspend fun deleteSession(conn: ServerConnection, sessionId: String): Boolean {
-        val response = httpClient.delete("${conn.baseUrl}/session/$sessionId") {
+        val response = clientFor(conn).delete("${conn.baseUrl}/session/$sessionId") {
             conn.authHeader?.let { header("Authorization", it) }
         }
         return response.status.isSuccess()
     }
 
     suspend fun updateSession(conn: ServerConnection, sessionId: String, title: String): Session {
-        return httpClient.patch("${conn.baseUrl}/session/$sessionId") {
+        return clientFor(conn).patch("${conn.baseUrl}/session/$sessionId") {
             conn.authHeader?.let { header("Authorization", it) }
             contentType(ContentType.Application.Json)
             setBody(mapOf("title" to title))
@@ -231,7 +246,7 @@ class OpenCodeApi @Inject constructor(
     }
 
     suspend fun abortSession(conn: ServerConnection, sessionId: String, directory: String? = null): Boolean {
-        val response = httpClient.post("${conn.baseUrl}/session/$sessionId/abort") {
+        val response = clientFor(conn).post("${conn.baseUrl}/session/$sessionId/abort") {
             conn.authHeader?.let { header("Authorization", it) }
             directory?.let { header("x-opencode-directory", it) }
         }
@@ -239,7 +254,7 @@ class OpenCodeApi @Inject constructor(
     }
 
     suspend fun getSessionDiff(conn: ServerConnection, sessionId: String): List<FileDiff> {
-        return httpClient.get("${conn.baseUrl}/session/$sessionId/diff") {
+        return clientFor(conn).get("${conn.baseUrl}/session/$sessionId/diff") {
             conn.authHeader?.let { header("Authorization", it) }
         }.body()
     }
@@ -249,7 +264,7 @@ class OpenCodeApi @Inject constructor(
      * POST /session/{sessionId}/share
      */
     suspend fun shareSession(conn: ServerConnection, sessionId: String): Session {
-        return httpClient.post("${conn.baseUrl}/session/$sessionId/share") {
+        return clientFor(conn).post("${conn.baseUrl}/session/$sessionId/share") {
             conn.authHeader?.let { header("Authorization", it) }
         }.body()
     }
@@ -259,7 +274,7 @@ class OpenCodeApi @Inject constructor(
      * DELETE /session/{sessionId}/share
      */
     suspend fun unshareSession(conn: ServerConnection, sessionId: String): Session {
-        return httpClient.delete("${conn.baseUrl}/session/$sessionId/share") {
+        return clientFor(conn).delete("${conn.baseUrl}/session/$sessionId/share") {
             conn.authHeader?.let { header("Authorization", it) }
         }.body()
     }
@@ -274,7 +289,7 @@ class OpenCodeApi @Inject constructor(
         providerId: String,
         modelId: String
     ): Boolean {
-        val response = httpClient.post("${conn.baseUrl}/session/$sessionId/summarize") {
+        val response = clientFor(conn).post("${conn.baseUrl}/session/$sessionId/summarize") {
             conn.authHeader?.let { header("Authorization", it) }
             contentType(ContentType.Application.Json)
             setBody(mapOf("providerID" to providerId, "modelID" to modelId))
@@ -287,7 +302,7 @@ class OpenCodeApi @Inject constructor(
      * POST /session/{sessionId}/revert
      */
     suspend fun revertSession(conn: ServerConnection, sessionId: String, messageId: String): Session {
-        return httpClient.post("${conn.baseUrl}/session/$sessionId/revert") {
+        return clientFor(conn).post("${conn.baseUrl}/session/$sessionId/revert") {
             conn.authHeader?.let { header("Authorization", it) }
             contentType(ContentType.Application.Json)
             setBody(mapOf("messageID" to messageId))
@@ -299,7 +314,7 @@ class OpenCodeApi @Inject constructor(
      * POST /session/{sessionId}/unrevert
      */
     suspend fun unrevertSession(conn: ServerConnection, sessionId: String): Session {
-        return httpClient.post("${conn.baseUrl}/session/$sessionId/unrevert") {
+        return clientFor(conn).post("${conn.baseUrl}/session/$sessionId/unrevert") {
             conn.authHeader?.let { header("Authorization", it) }
         }.body()
     }
@@ -312,7 +327,7 @@ class OpenCodeApi @Inject constructor(
         val body = buildMap<String, String> {
             messageId?.let { put("messageID", it) }
         }
-        return httpClient.post("${conn.baseUrl}/session/$sessionId/fork") {
+        return clientFor(conn).post("${conn.baseUrl}/session/$sessionId/fork") {
             conn.authHeader?.let { header("Authorization", it) }
             contentType(ContentType.Application.Json)
             setBody(body)
@@ -331,7 +346,7 @@ class OpenCodeApi @Inject constructor(
         arguments: String = "",
         directory: String? = null
     ): Boolean {
-        val response = httpClient.post("${conn.baseUrl}/session/$sessionId/command") {
+        val response = clientFor(conn).post("${conn.baseUrl}/session/$sessionId/command") {
             conn.authHeader?.let { header("Authorization", it) }
             directory?.let { header("x-opencode-directory", it) }
             contentType(ContentType.Application.Json)
@@ -352,7 +367,7 @@ class OpenCodeApi @Inject constructor(
         model: ModelSelection? = null,
         directory: String? = null
     ): Boolean {
-        val response = httpClient.post("${conn.baseUrl}/session/$sessionId/shell") {
+        val response = clientFor(conn).post("${conn.baseUrl}/session/$sessionId/shell") {
             conn.authHeader?.let { header("Authorization", it) }
             directory?.let { header("x-opencode-directory", it) }
             contentType(ContentType.Application.Json)
@@ -376,7 +391,7 @@ class OpenCodeApi @Inject constructor(
         if (BuildConfig.DEBUG) {
             Log.d("OpenCodeApi", "createPty: request")
         }
-        val response = httpClient.post("${conn.baseUrl}/pty") {
+        val response = clientFor(conn).post("${conn.baseUrl}/pty") {
             conn.authHeader?.let { header("Authorization", it) }
             directory?.let { header("x-opencode-directory", it) }
             contentType(ContentType.Application.Json)
@@ -450,7 +465,7 @@ class OpenCodeApi @Inject constructor(
     }
 
     suspend fun removePty(conn: ServerConnection, ptyId: String): Boolean {
-        val response = httpClient.delete("${conn.baseUrl}/pty/$ptyId") {
+        val response = clientFor(conn).delete("${conn.baseUrl}/pty/$ptyId") {
             conn.authHeader?.let { header("Authorization", it) }
         }
         return response.status.isSuccess()
@@ -467,7 +482,7 @@ class OpenCodeApi @Inject constructor(
         if (BuildConfig.DEBUG) {
             Log.d("OpenCodeApi", "updatePtySize: ${cols}x$rows")
         }
-        val response = httpClient.put("${conn.baseUrl}/pty/$ptyId") {
+        val response = clientFor(conn).put("${conn.baseUrl}/pty/$ptyId") {
             conn.authHeader?.let { header("Authorization", it) }
             directory?.let { header("x-opencode-directory", it) }
             contentType(ContentType.Application.Json)
@@ -490,7 +505,7 @@ class OpenCodeApi @Inject constructor(
             conn.baseUrl.startsWith("http://") -> conn.baseUrl.replaceFirst("http://", "ws://")
             else -> conn.baseUrl
         }
-        val session = httpClient.webSocketSession {
+        val session = clientFor(conn).webSocketSession {
             method = HttpMethod.Get
             url("$wsBase/pty/$ptyId/connect?cursor=$cursor")
             conn.authHeader?.let { header("Authorization", it) }
@@ -517,7 +532,7 @@ class OpenCodeApi @Inject constructor(
         before: String? = null,
         directory: String? = null,
     ): MessagePage {
-        val response = httpClient.get("${conn.baseUrl}/session/$sessionId/message") {
+        val response = clientFor(conn).get("${conn.baseUrl}/session/$sessionId/message") {
             conn.authHeader?.let { header("Authorization", it) }
             limit?.let { parameter("limit", it) }
             before?.let { parameter("before", it) }
@@ -531,7 +546,7 @@ class OpenCodeApi @Inject constructor(
 
     /** Returns messages as raw JSON string (for export without re-serialization). */
     suspend fun listMessagesRaw(conn: ServerConnection, sessionId: String): String {
-        return httpClient.get("${conn.baseUrl}/session/$sessionId/message") {
+        return clientFor(conn).get("${conn.baseUrl}/session/$sessionId/message") {
             conn.authHeader?.let { header("Authorization", it) }
         }.bodyAsText()
     }
@@ -551,7 +566,7 @@ class OpenCodeApi @Inject constructor(
     ) {
         var bytesWritten = 0L
         // Write session info (small, safe to hold in memory)
-        val sessionJson = httpClient.get("${conn.baseUrl}/session/$sessionId") {
+        val sessionJson = clientFor(conn).get("${conn.baseUrl}/session/$sessionId") {
             conn.authHeader?.let { header("Authorization", it) }
         }.bodyAsText()
         val header = """{"info":$sessionJson,"messages":"""
@@ -561,10 +576,13 @@ class OpenCodeApi @Inject constructor(
         onProgress(bytesWritten)
 
         // Stream messages via raw OkHttp to get true byte-level streaming
-        val okClient = okhttp3.OkHttpClient.Builder()
+        val okClientBuilder = okhttp3.OkHttpClient.Builder()
             .connectTimeout(15, java.util.concurrent.TimeUnit.SECONDS)
             .readTimeout(120, java.util.concurrent.TimeUnit.SECONDS)
-            .build()
+        if (conn.allowSelfSigned) {
+            dev.minios.ocremote.core.network.InsecureTls.applyToOkHttp(okClientBuilder)
+        }
+        val okClient = okClientBuilder.build()
         val request = okhttp3.Request.Builder()
             .url("${conn.baseUrl}/session/$sessionId/message")
             .apply { conn.authHeader?.let { addHeader("Authorization", it) } }
@@ -592,7 +610,7 @@ class OpenCodeApi @Inject constructor(
     }
 
     suspend fun getMessage(conn: ServerConnection, sessionId: String, messageId: String): MessageWithParts {
-        return httpClient.get("${conn.baseUrl}/session/$sessionId/message/$messageId") {
+        return clientFor(conn).get("${conn.baseUrl}/session/$sessionId/message/$messageId") {
             conn.authHeader?.let { header("Authorization", it) }
         }.body()
     }
@@ -613,7 +631,7 @@ class OpenCodeApi @Inject constructor(
         variant: String? = null,
         directory: String? = null
     ) {
-        val response = httpClient.post("${conn.baseUrl}/session/$sessionId/prompt_async") {
+        val response = clientFor(conn).post("${conn.baseUrl}/session/$sessionId/prompt_async") {
             conn.authHeader?.let { header("Authorization", it) }
             directory?.let { header("x-opencode-directory", it) }
             contentType(ContentType.Application.Json)
@@ -637,7 +655,7 @@ class OpenCodeApi @Inject constructor(
         directory: String? = null,
         workspaceId: String? = null,
     ) {
-        val response = httpClient.post("${conn.baseUrl}/api/session/$sessionId/agent") {
+        val response = clientFor(conn).post("${conn.baseUrl}/api/session/$sessionId/agent") {
             conn.authHeader?.let { header("Authorization", it) }
             directory?.let { parameter("directory", it) }
             workspaceId?.let { parameter("workspace", it) }
@@ -655,7 +673,7 @@ class OpenCodeApi @Inject constructor(
         directory: String? = null,
         workspaceId: String? = null,
     ) {
-        val response = httpClient.post("${conn.baseUrl}/api/session/$sessionId/model") {
+        val response = clientFor(conn).post("${conn.baseUrl}/api/session/$sessionId/model") {
             conn.authHeader?.let { header("Authorization", it) }
             directory?.let { parameter("directory", it) }
             workspaceId?.let { parameter("workspace", it) }
@@ -672,7 +690,7 @@ class OpenCodeApi @Inject constructor(
         directory: String? = null,
         workspaceId: String? = null,
     ): V2AdmittedPrompt {
-        val response = httpClient.post("${conn.baseUrl}/api/session/$sessionId/prompt") {
+        val response = clientFor(conn).post("${conn.baseUrl}/api/session/$sessionId/prompt") {
             conn.authHeader?.let { header("Authorization", it) }
             directory?.let { parameter("directory", it) }
             workspaceId?.let { parameter("workspace", it) }
@@ -701,7 +719,7 @@ class OpenCodeApi @Inject constructor(
             put("reply", reply)
             message?.let { put("message", it) }
         }
-        val result = httpClient.post("${conn.baseUrl}/permission/$requestId/reply") {
+        val result = clientFor(conn).post("${conn.baseUrl}/permission/$requestId/reply") {
             conn.authHeader?.let { header("Authorization", it) }
             directory?.let { header("x-opencode-directory", it) }
             contentType(ContentType.Application.Json)
@@ -715,7 +733,7 @@ class OpenCodeApi @Inject constructor(
      * GET /permission
      */
     suspend fun listPendingPermissions(conn: ServerConnection, directory: String? = null): List<PermissionRequest> {
-        return httpClient.get("${conn.baseUrl}/permission") {
+        return clientFor(conn).get("${conn.baseUrl}/permission") {
             conn.authHeader?.let { header("Authorization", it) }
             directory?.let { header("x-opencode-directory", it) }
         }.body()
@@ -724,7 +742,7 @@ class OpenCodeApi @Inject constructor(
     // ============ MCP ============
 
     suspend fun getMcpStatus(conn: ServerConnection): Map<String, McpStatus> {
-        val response = httpClient.get("${conn.baseUrl}/mcp") {
+        val response = clientFor(conn).get("${conn.baseUrl}/mcp") {
             conn.authHeader?.let { header("Authorization", it) }
         }
         if (!response.status.isSuccess()) throw RuntimeException("MCP status failed: ${response.status}")
@@ -743,7 +761,7 @@ class OpenCodeApi @Inject constructor(
         connect: Boolean,
     ): Boolean {
         val action = if (connect) "connect" else "disconnect"
-        val response = httpClient.post("${conn.baseUrl}/mcp/${name.encodeURLPathPart()}/$action") {
+        val response = clientFor(conn).post("${conn.baseUrl}/mcp/${name.encodeURLPathPart()}/$action") {
             conn.authHeader?.let { header("Authorization", it) }
         }
         if (!response.status.isSuccess()) throw RuntimeException("MCP $action failed: ${response.status}")
@@ -751,7 +769,7 @@ class OpenCodeApi @Inject constructor(
     }
 
     suspend fun startMcpAuth(conn: ServerConnection, name: String): McpAuthStart {
-        val response = httpClient.post("${conn.baseUrl}/mcp/${name.encodeURLPathPart()}/auth") {
+        val response = clientFor(conn).post("${conn.baseUrl}/mcp/${name.encodeURLPathPart()}/auth") {
             conn.authHeader?.let { header("Authorization", it) }
         }
         if (!response.status.isSuccess()) throw RuntimeException("MCP authentication failed: ${response.status}")
@@ -774,7 +792,7 @@ class OpenCodeApi @Inject constructor(
         val url = "${conn.baseUrl}/question/$requestId/reply"
         val bodyJson = json.encodeToString(QuestionReplyBody.serializer(), QuestionReplyBody(answers = answers))
         if (BuildConfig.DEBUG) Log.d("OpenCodeApi", "replyToQuestion: answers=${answers.size}")
-        val result = httpClient.post(url) {
+        val result = clientFor(conn).post(url) {
             conn.authHeader?.let { header("Authorization", it) }
             directory?.let { header("x-opencode-directory", it) }
             setBody(io.ktor.http.content.TextContent(bodyJson, ContentType.Application.Json))
@@ -794,7 +812,7 @@ class OpenCodeApi @Inject constructor(
     ): Boolean {
         val url = "${conn.baseUrl}/question/$requestId/reject"
         if (BuildConfig.DEBUG) Log.d("OpenCodeApi", "rejectQuestion: request")
-        val result = httpClient.post(url) {
+        val result = clientFor(conn).post(url) {
             conn.authHeader?.let { header("Authorization", it) }
             directory?.let { header("x-opencode-directory", it) }
         }
@@ -807,7 +825,7 @@ class OpenCodeApi @Inject constructor(
      * GET /question
      */
     suspend fun listPendingQuestions(conn: ServerConnection, directory: String? = null): List<QuestionRequest> {
-        return httpClient.get("${conn.baseUrl}/question") {
+        return clientFor(conn).get("${conn.baseUrl}/question") {
             conn.authHeader?.let { header("Authorization", it) }
             directory?.let { header("x-opencode-directory", it) }
         }.body()
@@ -820,7 +838,7 @@ class OpenCodeApi @Inject constructor(
      * GET /config/providers
      */
     suspend fun getProviders(conn: ServerConnection): ProvidersResponse {
-        return httpClient.get("${conn.baseUrl}/config/providers") {
+        return clientFor(conn).get("${conn.baseUrl}/config/providers") {
             conn.authHeader?.let { header("Authorization", it) }
         }.body()
     }
@@ -830,7 +848,7 @@ class OpenCodeApi @Inject constructor(
      * GET /provider
      */
     suspend fun listProviderCatalog(conn: ServerConnection): ProviderCatalogResponse {
-        return httpClient.get("${conn.baseUrl}/provider") {
+        return clientFor(conn).get("${conn.baseUrl}/provider") {
             conn.authHeader?.let { header("Authorization", it) }
         }.body()
     }
@@ -840,7 +858,7 @@ class OpenCodeApi @Inject constructor(
      * GET /provider/auth
      */
     suspend fun getProviderAuthMethods(conn: ServerConnection): Map<String, List<ProviderAuthMethod>> {
-        return httpClient.get("${conn.baseUrl}/provider/auth") {
+        return clientFor(conn).get("${conn.baseUrl}/provider/auth") {
             conn.authHeader?.let { header("Authorization", it) }
         }.body()
     }
@@ -854,7 +872,7 @@ class OpenCodeApi @Inject constructor(
         providerId: String,
         methodIndex: Int
     ): ProviderOauthAuthorization? {
-        val response = httpClient.post("${conn.baseUrl}/provider/$providerId/oauth/authorize") {
+        val response = clientFor(conn).post("${conn.baseUrl}/provider/$providerId/oauth/authorize") {
             conn.authHeader?.let { header("Authorization", it) }
             contentType(ContentType.Application.Json)
             setBody(ProviderOauthAuthorizeRequest(method = methodIndex))
@@ -894,7 +912,7 @@ class OpenCodeApi @Inject constructor(
         if (BuildConfig.DEBUG) {
             Log.d(TAG, "completeProviderOauth: POST /provider/$providerId/oauth/callback method=$methodIndex hasCode=${code != null}")
         }
-        val response = httpClient.post("${conn.baseUrl}/provider/$providerId/oauth/callback") {
+        val response = clientFor(conn).post("${conn.baseUrl}/provider/$providerId/oauth/callback") {
             conn.authHeader?.let { header("Authorization", it) }
             contentType(ContentType.Application.Json)
             setBody(body)
@@ -915,7 +933,7 @@ class OpenCodeApi @Inject constructor(
      * PUT /auth/{providerID}
      */
     suspend fun setProviderApiKey(conn: ServerConnection, providerId: String, apiKey: String): Boolean {
-        val response = httpClient.put("${conn.baseUrl}/auth/$providerId") {
+        val response = clientFor(conn).put("${conn.baseUrl}/auth/$providerId") {
             conn.authHeader?.let { header("Authorization", it) }
             contentType(ContentType.Application.Json)
             setBody(mapOf("type" to "api", "key" to apiKey))
@@ -929,7 +947,7 @@ class OpenCodeApi @Inject constructor(
      */
     suspend fun removeProviderAuth(conn: ServerConnection, providerId: String): Boolean {
         if (BuildConfig.DEBUG) Log.d(TAG, "removeProviderAuth: request")
-        val response = httpClient.delete("${conn.baseUrl}/auth/$providerId") {
+        val response = clientFor(conn).delete("${conn.baseUrl}/auth/$providerId") {
             conn.authHeader?.let { header("Authorization", it) }
         }
         if (BuildConfig.DEBUG) {
@@ -943,7 +961,7 @@ class OpenCodeApi @Inject constructor(
      * GET /config
      */
     suspend fun getConfig(conn: ServerConnection): ServerConfigResponse {
-        return httpClient.get("${conn.baseUrl}/config") {
+        return clientFor(conn).get("${conn.baseUrl}/config") {
             conn.authHeader?.let { header("Authorization", it) }
         }.body()
     }
@@ -953,7 +971,7 @@ class OpenCodeApi @Inject constructor(
      * GET /global/config
      */
     suspend fun getGlobalConfig(conn: ServerConnection): ServerConfigResponse {
-        return httpClient.get("${conn.baseUrl}/global/config") {
+        return clientFor(conn).get("${conn.baseUrl}/global/config") {
             conn.authHeader?.let { header("Authorization", it) }
         }.body()
     }
@@ -963,7 +981,7 @@ class OpenCodeApi @Inject constructor(
      * PATCH /config
      */
     suspend fun updateConfig(conn: ServerConnection, patch: ServerConfigPatch): ServerConfigResponse {
-        return httpClient.patch("${conn.baseUrl}/config") {
+        return clientFor(conn).patch("${conn.baseUrl}/config") {
             conn.authHeader?.let { header("Authorization", it) }
             contentType(ContentType.Application.Json)
             setBody(patch)
@@ -975,7 +993,7 @@ class OpenCodeApi @Inject constructor(
      * PATCH /global/config
      */
     suspend fun updateGlobalConfig(conn: ServerConnection, patch: ServerConfigPatch): ServerConfigResponse {
-        return httpClient.patch("${conn.baseUrl}/global/config") {
+        return clientFor(conn).patch("${conn.baseUrl}/global/config") {
             conn.authHeader?.let { header("Authorization", it) }
             contentType(ContentType.Application.Json)
             setBody(patch)
@@ -987,7 +1005,7 @@ class OpenCodeApi @Inject constructor(
      * POST /global/dispose
      */
     suspend fun disposeGlobal(conn: ServerConnection): Boolean {
-        val response = httpClient.post("${conn.baseUrl}/global/dispose") {
+        val response = clientFor(conn).post("${conn.baseUrl}/global/dispose") {
             conn.authHeader?.let { header("Authorization", it) }
         }
         return response.status.isSuccess()
@@ -1000,7 +1018,7 @@ class OpenCodeApi @Inject constructor(
      * GET /command
      */
     suspend fun listCommands(conn: ServerConnection): List<CommandInfo> {
-        return httpClient.get("${conn.baseUrl}/command") {
+        return clientFor(conn).get("${conn.baseUrl}/command") {
             conn.authHeader?.let { header("Authorization", it) }
         }.body()
     }
@@ -1008,14 +1026,14 @@ class OpenCodeApi @Inject constructor(
     // ============ Files ============
 
     suspend fun searchText(conn: ServerConnection, pattern: String): List<SearchMatch> {
-        return httpClient.get("${conn.baseUrl}/find") {
+        return clientFor(conn).get("${conn.baseUrl}/find") {
             conn.authHeader?.let { header("Authorization", it) }
             parameter("pattern", pattern)
         }.body()
     }
 
     suspend fun findFiles(conn: ServerConnection, query: String, type: String? = null, directory: String? = null, limit: Int? = null, dirs: String? = null): List<String> {
-        return httpClient.get("${conn.baseUrl}/find/file") {
+        return clientFor(conn).get("${conn.baseUrl}/find/file") {
             conn.authHeader?.let { header("Authorization", it) }
             directory?.let {
                 parameter("directory", it)
@@ -1029,14 +1047,14 @@ class OpenCodeApi @Inject constructor(
     }
 
     suspend fun readFile(conn: ServerConnection, path: String): FileContent {
-        return httpClient.get("${conn.baseUrl}/file/content") {
+        return clientFor(conn).get("${conn.baseUrl}/file/content") {
             conn.authHeader?.let { header("Authorization", it) }
             parameter("path", path)
         }.body()
     }
 
     suspend fun listDirectory(conn: ServerConnection, path: String = "", directory: String? = null): List<FileNode> {
-        return httpClient.get("${conn.baseUrl}/file") {
+        return clientFor(conn).get("${conn.baseUrl}/file") {
             conn.authHeader?.let { header("Authorization", it) }
             directory?.let {
                 parameter("directory", it)

--- a/app/src/main/kotlin/dev/minios/ocremote/data/api/SseClient.kt
+++ b/app/src/main/kotlin/dev/minios/ocremote/data/api/SseClient.kt
@@ -15,6 +15,7 @@ import kotlinx.coroutines.isActive
 import kotlinx.coroutines.withTimeoutOrNull
 import kotlinx.serialization.json.*
 import javax.inject.Inject
+import javax.inject.Named
 import javax.inject.Singleton
 
 private const val TAG = "SseClient"
@@ -53,9 +54,17 @@ internal fun isHighFrequencySseEvent(event: SseEvent): Boolean = when (event) {
  */
 @Singleton
 class SseClient @Inject constructor(
-    private val httpClient: HttpClient,
+    @Named("secure") private val httpClient: HttpClient,
+    @Named("insecure") private val insecureHttpClient: HttpClient,
     private val json: Json
 ) {
+
+    /**
+     * Pick the HTTP client matching the server's TLS preference.
+     * [ServerConnection.allowSelfSigned] selects the trust-all client.
+     */
+    private fun clientFor(conn: ServerConnection): HttpClient =
+        if (conn.allowSelfSigned) insecureHttpClient else httpClient
 
     /**
      * Connect to the global event stream.
@@ -71,7 +80,7 @@ class SseClient @Inject constructor(
         val sseUrl = "${conn.baseUrl}/global/event"
         Log.i(TAG, "Connecting to global SSE (auth=${conn.authHeader != null})")
 
-        val statement = httpClient.prepareGet(sseUrl) {
+        val statement = clientFor(conn).prepareGet(sseUrl) {
             conn.authHeader?.let { header("Authorization", it) }
             header("Accept", "text/event-stream")
             directory?.let { header("x-opencode-directory", it) }

--- a/app/src/main/kotlin/dev/minios/ocremote/data/repository/ServerRepository.kt
+++ b/app/src/main/kotlin/dev/minios/ocremote/data/repository/ServerRepository.kt
@@ -157,7 +157,8 @@ class ServerRepository @Inject constructor(
         username: String = "opencode",
         password: String? = null,
         name: String? = null,
-        autoConnect: Boolean = false
+        autoConnect: Boolean = false,
+        allowSelfSigned: Boolean = false
     ): ServerConfig {
         val server = ServerConfig(
             id = UUID.randomUUID().toString(),
@@ -166,6 +167,7 @@ class ServerRepository @Inject constructor(
             password = password,
             name = name,
             autoConnect = autoConnect,
+            allowSelfSigned = allowSelfSigned,
             lastConnected = null,
             isHealthy = false
         )
@@ -210,7 +212,12 @@ class ServerRepository @Inject constructor(
      */
     suspend fun checkHealth(server: ServerConfig): Result<ServerHealth> {
         return try {
-            val conn = ServerConnection.from(server.url, server.username, server.password)
+            val conn = ServerConnection.from(
+                server.url,
+                server.username,
+                server.password,
+                allowSelfSigned = server.allowSelfSigned,
+            )
             val health = api.getHealth(conn)
             
             // Update server health status

--- a/app/src/main/kotlin/dev/minios/ocremote/data/repository/SyncRepository.kt
+++ b/app/src/main/kotlin/dev/minios/ocremote/data/repository/SyncRepository.kt
@@ -31,6 +31,7 @@ import kotlinx.serialization.json.Json
 import java.security.MessageDigest
 import java.util.UUID
 import javax.inject.Inject
+import javax.inject.Named
 import javax.inject.Singleton
 
 enum class SyncBackend { NONE, GIST, WEBDAV }
@@ -126,7 +127,7 @@ class SyncRepository @Inject constructor(
     private val serverRepository: ServerRepository,
     private val diagnosticLogRepository: DiagnosticLogRepository,
     private val secretStore: LocalSyncSecretStore,
-    private val client: HttpClient,
+    @Named("secure") private val client: HttpClient,
     private val json: Json,
 ) {
     private val syncMutex = Mutex()

--- a/app/src/main/kotlin/dev/minios/ocremote/data/update/UpdateRepository.kt
+++ b/app/src/main/kotlin/dev/minios/ocremote/data/update/UpdateRepository.kt
@@ -36,6 +36,7 @@ import java.io.File
 import java.io.FileOutputStream
 import java.security.MessageDigest
 import javax.inject.Inject
+import javax.inject.Named
 import javax.inject.Singleton
 
 private const val RICH_UPDATE_MANIFEST_URL = "https://github.com/crim50n/oc-remote/releases/latest/download/update.json"
@@ -53,7 +54,7 @@ private const val TAG = "UpdateRepository"
 @Singleton
 class UpdateRepository @Inject constructor(
     @ApplicationContext private val context: Context,
-    private val client: HttpClient,
+    @Named("secure") private val client: HttpClient,
     private val json: Json,
     private val dataStore: DataStore<Preferences>,
 ) {

--- a/app/src/main/kotlin/dev/minios/ocremote/di/NetworkModule.kt
+++ b/app/src/main/kotlin/dev/minios/ocremote/di/NetworkModule.kt
@@ -9,6 +9,7 @@ import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
+import dev.minios.ocremote.core.network.InsecureTls
 import io.ktor.client.*
 import io.ktor.client.engine.okhttp.*
 import io.ktor.client.plugins.*
@@ -19,6 +20,7 @@ import io.ktor.client.plugins.logging.*
 import io.ktor.client.plugins.websocket.*
 import io.ktor.serialization.kotlinx.json.*
 import kotlinx.serialization.json.Json
+import javax.inject.Named
 import javax.inject.Singleton
 
 private val Context.dataStore: DataStore<Preferences> by preferencesDataStore(name = "opencode_prefs")
@@ -37,10 +39,18 @@ object NetworkModule {
         encodeDefaults = true
         explicitNulls = false
     }
-    
+
     @Provides
     @Singleton
-    fun provideHttpClient(json: Json): HttpClient = HttpClient(OkHttp) {
+    @Named("secure")
+    fun provideHttpClient(json: Json): HttpClient = buildHttpClient(json)
+
+    @Provides
+    @Singleton
+    @Named("insecure")
+    fun provideInsecureHttpClient(json: Json): HttpClient = buildHttpClient(json, trustAll = true)
+
+    private fun buildHttpClient(json: Json, trustAll: Boolean = false): HttpClient = HttpClient(OkHttp) {
         install(ContentNegotiation) {
             json(json)
         }
@@ -71,6 +81,10 @@ object NetworkModule {
             config {
                 // OkHttp-specific: disable response body buffering for streaming
                 retryOnConnectionFailure(true)
+                if (trustAll) {
+                    // Accept any certificate + hostname (opt-in per server).
+                    InsecureTls.applyToOkHttp(this)
+                }
             }
         }
         

--- a/app/src/main/kotlin/dev/minios/ocremote/domain/model/ServerConfig.kt
+++ b/app/src/main/kotlin/dev/minios/ocremote/domain/model/ServerConfig.kt
@@ -13,6 +13,7 @@ data class ServerConfig(
     val password: String? = null,
     val name: String? = null, // User-friendly name
     val autoConnect: Boolean = false,
+    val allowSelfSigned: Boolean = false,
     val lastConnected: Long? = null,
     val isHealthy: Boolean = false
 ) {

--- a/app/src/main/kotlin/dev/minios/ocremote/service/OpenCodeConnectionService.kt
+++ b/app/src/main/kotlin/dev/minios/ocremote/service/OpenCodeConnectionService.kt
@@ -264,15 +264,16 @@ class OpenCodeConnectionService : Service() {
         val serverId = intent?.getStringExtra("server_id")
         val serverUrl = intent?.getStringExtra("server_url")
         if (serverId != null && serverUrl != null) {
-            connect(
-                ServerConfig(
-                    id = serverId,
-                    url = serverUrl,
-                    username = intent.getStringExtra("server_username") ?: "opencode",
-                    password = intent.getStringExtra("server_password"),
-                    name = intent.getStringExtra("server_name"),
+                connect(
+                    ServerConfig(
+                        id = serverId,
+                        url = serverUrl,
+                        username = intent.getStringExtra("server_username") ?: "opencode",
+                        password = intent.getStringExtra("server_password"),
+                        name = intent.getStringExtra("server_name"),
+                        allowSelfSigned = intent.getBooleanExtra("server_allow_self_signed", false),
+                    )
                 )
-            )
             return START_NOT_STICKY
         }
 
@@ -332,7 +333,12 @@ class OpenCodeConnectionService : Service() {
         connections.compute(server.id) { _, existing ->
             if (existing != null && !existing.sseJob.isCompleted) return@compute existing
             replaced = existing
-            val conn = ServerConnection.from(server.url, server.username, server.password)
+            val conn = ServerConnection.from(
+                server.url,
+                server.username,
+                server.password,
+                allowSelfSigned = server.allowSelfSigned,
+            )
             ServerConnectionState(
                 config = server,
                 conn = conn,

--- a/app/src/main/kotlin/dev/minios/ocremote/ui/navigation/NavGraph.kt
+++ b/app/src/main/kotlin/dev/minios/ocremote/ui/navigation/NavGraph.kt
@@ -245,7 +245,8 @@ fun NavGraph(
                     password = server.password ?: "",
                     serverName = server.displayName,
                     serverId = server.id,
-                    sessionId = session.id
+                    sessionId = session.id,
+                    allowSelfSigned = server.allowSelfSigned,
                 )
                 Log.i(TAG, "Share → navigating to session ${session.id} on ${server.displayName}")
                 navController.navigate(route) { launchSingleTop = true }
@@ -259,7 +260,8 @@ fun NavGraph(
                     username = server.username,
                     password = server.password ?: "",
                     serverName = server.displayName,
-                    serverId = server.id
+                    serverId = server.id,
+                    allowSelfSigned = server.allowSelfSigned,
                 )
                 Log.i(TAG, "Share → navigating to session list on ${server.displayName}")
                 navController.navigate(route) { launchSingleTop = true }
@@ -305,7 +307,8 @@ fun NavGraph(
                         password = deepLink.password,
                         serverName = deepLink.serverName,
                         serverId = deepLink.serverId,
-                        sessionId = sessionId
+                        sessionId = sessionId,
+                        allowSelfSigned = deepLink.allowSelfSigned,
                     )
                     val currentSessionId = navController.currentBackStackEntry
                         ?.arguments
@@ -361,17 +364,17 @@ fun NavGraph(
         composable(Screen.Home.route) {
             HomeScreen(
                 addServerRequest = addServerRequest,
-                onNavigateToSessions = { serverUrl, username, password, serverName, serverId ->
+                onNavigateToSessions = { serverUrl, username, password, serverName, serverId, allowSelfSigned ->
                     navController.navigate(
-                        Screen.SessionList.createRoute(serverUrl, username, password, serverName, serverId)
+                        Screen.SessionList.createRoute(serverUrl, username, password, serverName, serverId, allowSelfSigned)
                     )
                 },
                 onNavigateToCrossServerSessions = {
                     navController.navigate(Screen.CrossServerSessions.route)
                 },
-                onNavigateToServerSettings = { serverUrl, username, password, serverName, serverId ->
+                onNavigateToServerSettings = { serverUrl, username, password, serverName, serverId, allowSelfSigned ->
                     navController.navigate(
-                        Screen.ServerSettings.createRoute(serverUrl, username, password, serverName, serverId)
+                        Screen.ServerSettings.createRoute(serverUrl, username, password, serverName, serverId, allowSelfSigned)
                     )
                 },
                 onNavigateToSettings = {
@@ -395,6 +398,7 @@ fun NavGraph(
                             serverName = item.server.displayName,
                             serverId = item.server.id,
                             sessionId = item.session.id,
+                            allowSelfSigned = item.server.allowSelfSigned,
                         ),
                     )
                 },
@@ -405,6 +409,7 @@ fun NavGraph(
                         putExtra("server_url", server.url)
                         putExtra("server_username", server.username)
                         putExtra("server_password", server.password)
+                        putExtra("server_allow_self_signed", server.allowSelfSigned)
                     }
                     ContextCompat.startForegroundService(context, intent)
                 },
@@ -433,13 +438,14 @@ fun NavGraph(
         }
 
         composable(
-            route = "server_settings?serverUrl={serverUrl}&username={username}&password={password}&serverName={serverName}&serverId={serverId}",
+            route = "server_settings?serverUrl={serverUrl}&username={username}&password={password}&serverName={serverName}&serverId={serverId}&allowSelfSigned={allowSelfSigned}",
             arguments = listOf(
                 navArgument("serverUrl") { type = NavType.StringType },
                 navArgument("username") { type = NavType.StringType },
                 navArgument("password") { type = NavType.StringType },
                 navArgument("serverName") { type = NavType.StringType },
                 navArgument("serverId") { type = NavType.StringType },
+                navArgument("allowSelfSigned") { type = NavType.BoolType; defaultValue = false },
             )
         ) {
             val serverUrl = it.arguments?.getString("serverUrl").orEmpty()
@@ -447,6 +453,7 @@ fun NavGraph(
             val password = it.arguments?.getString("password").orEmpty()
             val serverName = it.arguments?.getString("serverName").orEmpty()
             val serverId = it.arguments?.getString("serverId").orEmpty()
+            val allowSelfSigned = it.arguments?.getBoolean("allowSelfSigned") ?: false
             ServerSettingsScreen(
                 onNavigateBack = { navController.popBackStack() },
                 onOpenProviders = {
@@ -456,7 +463,8 @@ fun NavGraph(
                             username = username,
                             password = password,
                             serverName = serverName,
-                            serverId = serverId
+                            serverId = serverId,
+                            allowSelfSigned = allowSelfSigned,
                         )
                     )
                 },
@@ -467,7 +475,8 @@ fun NavGraph(
                             username = username,
                             password = password,
                             serverName = serverName,
-                            serverId = serverId
+                            serverId = serverId,
+                            allowSelfSigned = allowSelfSigned,
                         )
                     )
                 },
@@ -479,6 +488,7 @@ fun NavGraph(
                             password = password,
                             serverName = serverName,
                             serverId = serverId,
+                            allowSelfSigned = allowSelfSigned,
                         )
                     )
                 }
@@ -486,13 +496,14 @@ fun NavGraph(
         }
 
         composable(
-            route = "server_providers?serverUrl={serverUrl}&username={username}&password={password}&serverName={serverName}&serverId={serverId}",
+            route = "server_providers?serverUrl={serverUrl}&username={username}&password={password}&serverName={serverName}&serverId={serverId}&allowSelfSigned={allowSelfSigned}",
             arguments = listOf(
                 navArgument("serverUrl") { type = NavType.StringType },
                 navArgument("username") { type = NavType.StringType },
                 navArgument("password") { type = NavType.StringType },
                 navArgument("serverName") { type = NavType.StringType },
                 navArgument("serverId") { type = NavType.StringType },
+                navArgument("allowSelfSigned") { type = NavType.BoolType; defaultValue = false },
             )
         ) {
             ServerProvidersScreen(
@@ -501,13 +512,14 @@ fun NavGraph(
         }
 
         composable(
-            route = "server_model_filter?serverUrl={serverUrl}&username={username}&password={password}&serverName={serverName}&serverId={serverId}",
+            route = "server_model_filter?serverUrl={serverUrl}&username={username}&password={password}&serverName={serverName}&serverId={serverId}&allowSelfSigned={allowSelfSigned}",
             arguments = listOf(
                 navArgument("serverUrl") { type = NavType.StringType },
                 navArgument("username") { type = NavType.StringType },
                 navArgument("password") { type = NavType.StringType },
                 navArgument("serverName") { type = NavType.StringType },
                 navArgument("serverId") { type = NavType.StringType },
+                navArgument("allowSelfSigned") { type = NavType.BoolType; defaultValue = false },
             )
         ) {
             ServerModelFilterScreen(
@@ -516,13 +528,14 @@ fun NavGraph(
         }
 
         composable(
-            route = "server_mcp?serverUrl={serverUrl}&username={username}&password={password}&serverName={serverName}&serverId={serverId}",
+            route = "server_mcp?serverUrl={serverUrl}&username={username}&password={password}&serverName={serverName}&serverId={serverId}&allowSelfSigned={allowSelfSigned}",
             arguments = listOf(
                 navArgument("serverUrl") { type = NavType.StringType },
                 navArgument("username") { type = NavType.StringType },
                 navArgument("password") { type = NavType.StringType },
                 navArgument("serverName") { type = NavType.StringType },
                 navArgument("serverId") { type = NavType.StringType },
+                navArgument("allowSelfSigned") { type = NavType.BoolType; defaultValue = false },
             )
         ) {
             ServerMcpScreen(onNavigateBack = { navController.popBackStack() })
@@ -584,13 +597,14 @@ fun NavGraph(
         
         // ============ Session List Screen (native) ============
         composable(
-            route = "sessions?serverUrl={serverUrl}&username={username}&password={password}&serverName={serverName}&serverId={serverId}",
+            route = "sessions?serverUrl={serverUrl}&username={username}&password={password}&serverName={serverName}&serverId={serverId}&allowSelfSigned={allowSelfSigned}",
             arguments = listOf(
                 navArgument("serverUrl") { type = NavType.StringType },
                 navArgument("username") { type = NavType.StringType },
                 navArgument("password") { type = NavType.StringType },
                 navArgument("serverName") { type = NavType.StringType },
-                navArgument("serverId") { type = NavType.StringType }
+                navArgument("serverId") { type = NavType.StringType },
+                navArgument("allowSelfSigned") { type = NavType.BoolType; defaultValue = false },
             )
         ) { backStackEntry ->
             val serverUrl = backStackEntry.arguments?.getString("serverUrl").orEmpty()
@@ -598,6 +612,7 @@ fun NavGraph(
             val password = backStackEntry.arguments?.getString("password").orEmpty()
             val serverName = backStackEntry.arguments?.getString("serverName").orEmpty()
             val serverId = backStackEntry.arguments?.getString("serverId").orEmpty()
+            val allowSelfSigned = backStackEntry.arguments?.getBoolean("allowSelfSigned") ?: false
 
             SessionListScreen(
                 onNavigateToChat = { sessionId, openTerminal ->
@@ -609,7 +624,8 @@ fun NavGraph(
                             serverName = serverName,
                             serverId = serverId,
                             sessionId = sessionId,
-                            openTerminal = openTerminal
+                            openTerminal = openTerminal,
+                            allowSelfSigned = allowSelfSigned,
                         )
                     )
                 },
@@ -621,7 +637,7 @@ fun NavGraph(
         
         // ============ Chat Screen (native) ============
         composable(
-            route = "chat?serverUrl={serverUrl}&username={username}&password={password}&serverName={serverName}&serverId={serverId}&sessionId={sessionId}&openTerminal={openTerminal}",
+            route = "chat?serverUrl={serverUrl}&username={username}&password={password}&serverName={serverName}&serverId={serverId}&sessionId={sessionId}&openTerminal={openTerminal}&allowSelfSigned={allowSelfSigned}",
             arguments = listOf(
                 navArgument("serverUrl") { type = NavType.StringType },
                 navArgument("username") { type = NavType.StringType },
@@ -629,7 +645,8 @@ fun NavGraph(
                 navArgument("serverName") { type = NavType.StringType },
                 navArgument("serverId") { type = NavType.StringType },
                 navArgument("sessionId") { type = NavType.StringType },
-                navArgument("openTerminal") { type = NavType.BoolType; defaultValue = false }
+                navArgument("openTerminal") { type = NavType.BoolType; defaultValue = false },
+                navArgument("allowSelfSigned") { type = NavType.BoolType; defaultValue = false },
             )
         ) { backStackEntry ->
             val serverUrl = backStackEntry.arguments?.getString("serverUrl").orEmpty()
@@ -639,6 +656,7 @@ fun NavGraph(
             val serverId = backStackEntry.arguments?.getString("serverId").orEmpty()
             val sessionId = backStackEntry.arguments?.getString("sessionId").orEmpty()
             val openTerminal = backStackEntry.arguments?.getBoolean("openTerminal") ?: false
+            val allowSelfSigned = backStackEntry.arguments?.getBoolean("allowSelfSigned") ?: false
 
             // Only pass shared attachments to the targeted session, then clear them
             val attachmentsForThisSession = if (pendingShareSessionId == sessionId && pendingShareUris.isNotEmpty()) {
@@ -658,11 +676,12 @@ fun NavGraph(
                         password = password,
                         serverName = serverName,
                         serverId = serverId,
-                        sessionId = newSessionId
+                        sessionId = newSessionId,
+                        allowSelfSigned = allowSelfSigned,
                     )
                     navController.navigate(route) {
                         // Pop current chat so back goes to session list, not old session
-                        popUpTo("sessions?serverUrl={serverUrl}&username={username}&password={password}&serverName={serverName}&serverId={serverId}") {
+                        popUpTo("sessions?serverUrl={serverUrl}&username={username}&password={password}&serverName={serverName}&serverId={serverId}&allowSelfSigned={allowSelfSigned}") {
                             inclusive = false
                         }
                     }
@@ -676,6 +695,7 @@ fun NavGraph(
                             serverName = serverName,
                             serverId = serverId,
                             sessionId = childSessionId,
+                            allowSelfSigned = allowSelfSigned,
                         ),
                     )
                 },

--- a/app/src/main/kotlin/dev/minios/ocremote/ui/navigation/Screen.kt
+++ b/app/src/main/kotlin/dev/minios/ocremote/ui/navigation/Screen.kt
@@ -36,14 +36,15 @@ sealed class Screen(val route: String) {
             username: String,
             password: String,
             serverName: String,
-            serverId: String
+            serverId: String,
+            allowSelfSigned: Boolean = false,
         ): String {
             val encodedUrl = encodeNavigationArgument(serverUrl)
             val encodedUsername = encodeNavigationArgument(username)
             val encodedPassword = encodeNavigationArgument(password)
             val encodedName = encodeNavigationArgument(serverName)
             val encodedServerId = encodeNavigationArgument(serverId)
-            return "sessions?serverUrl=$encodedUrl&username=$encodedUsername&password=$encodedPassword&serverName=$encodedName&serverId=$encodedServerId"
+            return "sessions?serverUrl=$encodedUrl&username=$encodedUsername&password=$encodedPassword&serverName=$encodedName&serverId=$encodedServerId&allowSelfSigned=$allowSelfSigned"
         }
     }
     
@@ -56,6 +57,7 @@ sealed class Screen(val route: String) {
             serverId: String,
             sessionId: String,
             openTerminal: Boolean = false,
+            allowSelfSigned: Boolean = false,
         ): String {
             val encodedUrl = encodeNavigationArgument(serverUrl)
             val encodedUsername = encodeNavigationArgument(username)
@@ -63,7 +65,7 @@ sealed class Screen(val route: String) {
             val encodedName = encodeNavigationArgument(serverName)
             val encodedServerId = encodeNavigationArgument(serverId)
             val encodedSessionId = encodeNavigationArgument(sessionId)
-            return "chat?serverUrl=$encodedUrl&username=$encodedUsername&password=$encodedPassword&serverName=$encodedName&serverId=$encodedServerId&sessionId=$encodedSessionId&openTerminal=$openTerminal"
+            return "chat?serverUrl=$encodedUrl&username=$encodedUsername&password=$encodedPassword&serverName=$encodedName&serverId=$encodedServerId&sessionId=$encodedSessionId&openTerminal=$openTerminal&allowSelfSigned=$allowSelfSigned"
         }
     }
 
@@ -73,14 +75,15 @@ sealed class Screen(val route: String) {
             username: String,
             password: String,
             serverName: String,
-            serverId: String
+            serverId: String,
+            allowSelfSigned: Boolean = false,
         ): String {
             val encodedUrl = encodeNavigationArgument(serverUrl)
             val encodedUsername = encodeNavigationArgument(username)
             val encodedPassword = encodeNavigationArgument(password)
             val encodedName = encodeNavigationArgument(serverName)
             val encodedServerId = encodeNavigationArgument(serverId)
-            return "server_settings?serverUrl=$encodedUrl&username=$encodedUsername&password=$encodedPassword&serverName=$encodedName&serverId=$encodedServerId"
+            return "server_settings?serverUrl=$encodedUrl&username=$encodedUsername&password=$encodedPassword&serverName=$encodedName&serverId=$encodedServerId&allowSelfSigned=$allowSelfSigned"
         }
     }
 
@@ -90,14 +93,15 @@ sealed class Screen(val route: String) {
             username: String,
             password: String,
             serverName: String,
-            serverId: String
+            serverId: String,
+            allowSelfSigned: Boolean = false,
         ): String {
             val encodedUrl = encodeNavigationArgument(serverUrl)
             val encodedUsername = encodeNavigationArgument(username)
             val encodedPassword = encodeNavigationArgument(password)
             val encodedName = encodeNavigationArgument(serverName)
             val encodedServerId = encodeNavigationArgument(serverId)
-            return "server_providers?serverUrl=$encodedUrl&username=$encodedUsername&password=$encodedPassword&serverName=$encodedName&serverId=$encodedServerId"
+            return "server_providers?serverUrl=$encodedUrl&username=$encodedUsername&password=$encodedPassword&serverName=$encodedName&serverId=$encodedServerId&allowSelfSigned=$allowSelfSigned"
         }
     }
 
@@ -107,14 +111,15 @@ sealed class Screen(val route: String) {
             username: String,
             password: String,
             serverName: String,
-            serverId: String
+            serverId: String,
+            allowSelfSigned: Boolean = false,
         ): String {
             val encodedUrl = encodeNavigationArgument(serverUrl)
             val encodedUsername = encodeNavigationArgument(username)
             val encodedPassword = encodeNavigationArgument(password)
             val encodedName = encodeNavigationArgument(serverName)
             val encodedServerId = encodeNavigationArgument(serverId)
-            return "server_model_filter?serverUrl=$encodedUrl&username=$encodedUsername&password=$encodedPassword&serverName=$encodedName&serverId=$encodedServerId"
+            return "server_model_filter?serverUrl=$encodedUrl&username=$encodedUsername&password=$encodedPassword&serverName=$encodedName&serverId=$encodedServerId&allowSelfSigned=$allowSelfSigned"
         }
     }
 
@@ -125,13 +130,14 @@ sealed class Screen(val route: String) {
             password: String,
             serverName: String,
             serverId: String,
+            allowSelfSigned: Boolean = false,
         ): String {
             val encodedUrl = encodeNavigationArgument(serverUrl)
             val encodedUsername = encodeNavigationArgument(username)
             val encodedPassword = encodeNavigationArgument(password)
             val encodedName = encodeNavigationArgument(serverName)
             val encodedServerId = encodeNavigationArgument(serverId)
-            return "server_mcp?serverUrl=$encodedUrl&username=$encodedUsername&password=$encodedPassword&serverName=$encodedName&serverId=$encodedServerId"
+            return "server_mcp?serverUrl=$encodedUrl&username=$encodedUsername&password=$encodedPassword&serverName=$encodedName&serverId=$encodedServerId&allowSelfSigned=$allowSelfSigned"
         }
     }
     

--- a/app/src/main/kotlin/dev/minios/ocremote/ui/screens/chat/ChatViewModel.kt
+++ b/app/src/main/kotlin/dev/minios/ocremote/ui/screens/chat/ChatViewModel.kt
@@ -235,7 +235,12 @@ class ChatViewModel @Inject constructor(
     val serverId: String = savedStateHandle.get<String>("serverId").orEmpty()
     val sessionId: String = savedStateHandle.get<String>("sessionId").orEmpty()
 
-    private val conn = ServerConnection.from(serverUrl, username, password.ifEmpty { null })
+    private val conn = ServerConnection.from(
+        serverUrl,
+        username,
+        password.ifEmpty { null },
+        allowSelfSigned = savedStateHandle.get<Boolean>("allowSelfSigned") ?: false,
+    )
 
     private val _isLoading = MutableStateFlow(true)
     private val _error = MutableStateFlow<String?>(null)

--- a/app/src/main/kotlin/dev/minios/ocremote/ui/screens/home/HomeScreen.kt
+++ b/app/src/main/kotlin/dev/minios/ocremote/ui/screens/home/HomeScreen.kt
@@ -126,9 +126,9 @@ private fun PulsingDotsIndicator(
 @Composable
 fun HomeScreen(
     addServerRequest: Int = 0,
-    onNavigateToSessions: (serverUrl: String, username: String, password: String, serverName: String, serverId: String) -> Unit = { _, _, _, _, _ -> },
+    onNavigateToSessions: (serverUrl: String, username: String, password: String, serverName: String, serverId: String, allowSelfSigned: Boolean) -> Unit = { _, _, _, _, _, _ -> },
     onNavigateToCrossServerSessions: () -> Unit = {},
-    onNavigateToServerSettings: (serverUrl: String, username: String, password: String, serverName: String, serverId: String) -> Unit = { _, _, _, _, _ -> },
+    onNavigateToServerSettings: (serverUrl: String, username: String, password: String, serverName: String, serverId: String, allowSelfSigned: Boolean) -> Unit = { _, _, _, _, _, _ -> },
     onNavigateToSettings: () -> Unit = {},
     onNavigateToAbout: () -> Unit = {},
     viewModel: HomeViewModel = hiltViewModel()
@@ -331,6 +331,7 @@ fun HomeScreen(
                                                 server.password ?: "",
                                                 server.displayName,
                                                 server.id,
+                                                server.allowSelfSigned,
                                             )
                                         }
                                     },
@@ -342,6 +343,7 @@ fun HomeScreen(
                                                 server.password ?: "",
                                                 server.displayName,
                                                 server.id,
+                                                server.allowSelfSigned,
                                             )
                                         }
                                     },
@@ -388,7 +390,8 @@ fun HomeScreen(
                                         server.username,
                                         server.password ?: "",
                                         server.displayName,
-                                        server.id
+                                        server.id,
+                                        server.allowSelfSigned,
                                     )
                                 },
                                 onServerSettings = {
@@ -397,7 +400,8 @@ fun HomeScreen(
                                         server.username,
                                         server.password ?: "",
                                         server.displayName,
-                                        server.id
+                                        server.id,
+                                        server.allowSelfSigned,
                                     )
                                 },
                                 onEdit = { viewModel.showEditServerDialog(server) },
@@ -414,8 +418,8 @@ fun HomeScreen(
             ServerDialog(
                 server = uiState.editingServer,
                 onDismiss = { viewModel.hideServerDialog() },
-                onSave = { name, url, username, password, autoConnect ->
-                    viewModel.saveServer(name, url, username, password, autoConnect)
+                onSave = { name, url, username, password, autoConnect, allowSelfSigned ->
+                    viewModel.saveServer(name, url, username, password, autoConnect, allowSelfSigned)
                 }
             )
         }

--- a/app/src/main/kotlin/dev/minios/ocremote/ui/screens/home/HomeViewModel.kt
+++ b/app/src/main/kotlin/dev/minios/ocremote/ui/screens/home/HomeViewModel.kt
@@ -299,7 +299,12 @@ class HomeViewModel @Inject constructor(
                 }
 
                 try {
-                    val conn = ServerConnection.from(server.url, server.username, server.password)
+                    val conn = ServerConnection.from(
+                        server.url,
+                        server.username,
+                        server.password,
+                        allowSelfSigned = server.allowSelfSigned,
+                    )
                     api.getProviders(conn)
                     _uiState.update {
                         it.copy(
@@ -356,7 +361,8 @@ class HomeViewModel @Inject constructor(
         url: String,
         username: String,
         password: String,
-        autoConnect: Boolean
+        autoConnect: Boolean,
+        allowSelfSigned: Boolean
     ) {
         viewModelScope.launch {
             val editingServer = _uiState.value.editingServer
@@ -367,7 +373,8 @@ class HomeViewModel @Inject constructor(
                     url = url,
                     username = username,
                     password = password,
-                    autoConnect = autoConnect
+                    autoConnect = autoConnect,
+                    allowSelfSigned = allowSelfSigned,
                 )
                 serverRepository.updateServer(updatedServer)
             } else {
@@ -376,7 +383,8 @@ class HomeViewModel @Inject constructor(
                     username = username,
                     password = password,
                     name = name,
-                    autoConnect = autoConnect
+                    autoConnect = autoConnect,
+                    allowSelfSigned = allowSelfSigned,
                 )
             }
             

--- a/app/src/main/kotlin/dev/minios/ocremote/ui/screens/home/ServerDialog.kt
+++ b/app/src/main/kotlin/dev/minios/ocremote/ui/screens/home/ServerDialog.kt
@@ -81,13 +81,14 @@ private fun deriveServerNameFromUrl(normalizedUrl: String): String {
 fun ServerDialog(
     server: ServerConfig?,
     onDismiss: () -> Unit,
-    onSave: (name: String, url: String, username: String, password: String, autoConnect: Boolean) -> Unit
+    onSave: (name: String, url: String, username: String, password: String, autoConnect: Boolean, allowSelfSigned: Boolean) -> Unit
 ) {
     var name by remember { mutableStateOf(server?.name ?: "") }
     var url by remember { mutableStateOf(server?.url ?: "http://") }
     var username by remember { mutableStateOf(server?.username ?: "opencode") }
     var password by remember { mutableStateOf(server?.password ?: "") }
     var autoConnect by remember { mutableStateOf(server?.autoConnect ?: false) }
+    var allowSelfSigned by remember { mutableStateOf(server?.allowSelfSigned ?: false) }
 
     var urlError by remember { mutableStateOf<String?>(null) }
 
@@ -211,6 +212,40 @@ fun ServerDialog(
                             )
                         }
                     }
+
+                    Surface(
+                        shape = RoundedCornerShape(12.dp),
+                        color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.24f),
+                        border = BorderStroke(1.dp, MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.4f)),
+                        modifier = Modifier.fillMaxWidth()
+                    ) {
+                        Row(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(horizontal = 14.dp, vertical = 12.dp),
+                            horizontalArrangement = Arrangement.spacedBy(12.dp),
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            Column(modifier = Modifier.weight(1f)) {
+                                Text(
+                                    text = stringResource(R.string.server_allow_self_signed),
+                                    style = MaterialTheme.typography.titleSmall
+                                )
+                                Text(
+                                    text = stringResource(R.string.server_allow_self_signed_desc),
+                                    style = MaterialTheme.typography.bodySmall,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                    maxLines = 3,
+                                    overflow = TextOverflow.Ellipsis
+                                )
+                            }
+                            Switch(
+                                checked = allowSelfSigned,
+                                onCheckedChange = { allowSelfSigned = it },
+                                colors = switchColors
+                            )
+                        }
+                    }
                 }
 
                 AppDialogActions(
@@ -235,6 +270,7 @@ fun ServerDialog(
                                 username.ifBlank { "opencode" },
                                 password,
                                 autoConnect,
+                                allowSelfSigned,
                             )
                         }
                     },

--- a/app/src/main/kotlin/dev/minios/ocremote/ui/screens/server/ServerMcpViewModel.kt
+++ b/app/src/main/kotlin/dev/minios/ocremote/ui/screens/server/ServerMcpViewModel.kt
@@ -46,6 +46,7 @@ class ServerMcpViewModel @Inject constructor(
         savedStateHandle.get<String>("serverUrl").orEmpty(),
         savedStateHandle.get<String>("username").orEmpty(),
         savedStateHandle.get<String>("password").orEmpty().ifEmpty { null },
+        allowSelfSigned = savedStateHandle.get<Boolean>("allowSelfSigned") ?: false,
     )
 
     private val _uiState = MutableStateFlow(ServerMcpUiState())

--- a/app/src/main/kotlin/dev/minios/ocremote/ui/screens/server/ServerSettingsViewModel.kt
+++ b/app/src/main/kotlin/dev/minios/ocremote/ui/screens/server/ServerSettingsViewModel.kt
@@ -106,7 +106,12 @@ class ServerSettingsViewModel @Inject constructor(
     private val serverId: String = savedStateHandle.get<String>("serverId").orEmpty()
     private val serverName: String = savedStateHandle.get<String>("serverName").orEmpty()
 
-    private val conn = ServerConnection.from(serverUrl, username, password.ifEmpty { null })
+    private val conn = ServerConnection.from(
+        serverUrl,
+        username,
+        password.ifEmpty { null },
+        allowSelfSigned = savedStateHandle.get<Boolean>("allowSelfSigned") ?: false,
+    )
 
     private val _allProviders = MutableStateFlow<List<ProviderInfo>>(emptyList())
     private val _providerCatalog = MutableStateFlow<List<ProviderInfo>>(emptyList())

--- a/app/src/main/kotlin/dev/minios/ocremote/ui/screens/sessions/SessionListViewModel.kt
+++ b/app/src/main/kotlin/dev/minios/ocremote/ui/screens/sessions/SessionListViewModel.kt
@@ -168,7 +168,12 @@ class SessionListViewModel @Inject constructor(
     val serverName: String = savedStateHandle.get<String>("serverName").orEmpty()
     val serverId: String = savedStateHandle.get<String>("serverId").orEmpty()
 
-    private val conn = ServerConnection.from(serverUrl, username, password.ifEmpty { null })
+    private val conn = ServerConnection.from(
+        serverUrl,
+        username,
+        password.ifEmpty { null },
+        allowSelfSigned = savedStateHandle.get<Boolean>("allowSelfSigned") ?: false,
+    )
 
     val groupSessionsByProject: StateFlow<Boolean> = settingsRepository.groupSessionsByProject.stateIn(
         viewModelScope,

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -124,6 +124,8 @@
     <string name="server_invalid_url">Invalid URL format</string>
     <string name="server_auto_connect">Auto-connect on app launch</string>
     <string name="server_auto_connect_desc">Automatically connect when the app starts</string>
+    <string name="server_allow_self_signed">Allow self-signed certificates</string>
+    <string name="server_allow_self_signed_desc">Skip certificate validation. Only for trusted servers without a valid SSL certificate.</string>
     
     <!-- Session Screen -->
     <string name="sessions_title">Sessions</string>


### PR DESCRIPTION
## Summary
Adds an **"Allow self-signed certificates"** toggle to the add/edit server dialog so users can connect to servers that use self-signed (or otherwise untrusted) TLS certificates.

By default nothing changes — the toggle is off and certificate validation is fully enforced. When enabled for a specific server, only that server's connections skip TLS certificate verification (a trust-all socket factory + hostname verifier), never the default client.

## Changes
- `ServerConfig`: new `allowSelfSigned: Boolean = false` field (persisted via existing DataStore serialization).
- `NetworkModule`: split `HttpClient` into two Hilt singletons — `@Named("secure")` (default, unchanged behavior) and `@Named("insecure")` (trust-all).
- New `InsecureTls` utility (`core/network/InsecureTls.kt`) providing the trust-all manager, SSL socket factory, and a lenient hostname verifier.
- `OpenCodeApi` / `SseClient`: accept both clients and select per connection via `ServerConnection.allowSelfSigned`; the raw `OkHttpClient` used by the "export session" feature applies the same trust-all config when the flag is set.
- `ServerDialog` / `HomeViewModel` / `ServerRepository`: new toggle + persistence wiring.
- Navigation args (`sessions`, `chat`, `server_settings`, `server_providers`, `server_model_filter`, `server_mcp`) and the connection-service intent extras propagate `allowSelfSigned`.
- `SyncRepository` / `UpdateRepository` explicitly use the secure (default) client.

## Testing
- Built successfully with `./gradlew :app:assembleDebug` (AGP 8.4 / JDK 17).
- Manual test against a self-signed HTTPS server: with toggle **on** the app connects; with toggle **off** it fails with a certificate error as before.