### PR TITLE
fix: group global sessions by directory

### DIFF
--- a/app/src/main/kotlin/dev/minios/ocremote/ui/screens/sessions/SessionListViewModel.kt
+++ b/app/src/main/kotlin/dev/minios/ocremote/ui/screens/sessions/SessionListViewModel.kt
@@ -41,6 +41,9 @@ import javax.inject.Inject
 
 private const val TAG = "SessionListViewModel"
 
+/** OpenCode's catch-all project id; not authoritative for grouping. */
+private const val GLOBAL_PROJECT_ID = "global"
+
 data class SessionListUiState(
     val sessionGroups: List<ProjectSessionGroup> = emptyList(),
     val projects: List<Project> = emptyList(),
@@ -80,9 +83,15 @@ internal fun buildProjectSessionGroups(
         }
     }
     fun projectFor(session: Session): Project? {
-        projects.firstOrNull { it.id.isNotBlank() && it.id == session.projectId }?.let { return it }
+        // OpenCode assigns projectId "global" to sessions whose real project is only
+        // known via their directory, so treat it as non-authoritative and group by path.
+        val isGlobalSession = session.projectId == GLOBAL_PROJECT_ID
+        if (!isGlobalSession) {
+            projects.firstOrNull { it.id.isNotBlank() && it.id == session.projectId }?.let { return it }
+        }
         val directory = normalized(session.directory)
         return projects
+            .filter { project -> !isGlobalSession || project.id != GLOBAL_PROJECT_ID }
             .filter { project ->
                 val root = normalized(project.worktree.ifBlank { project.path })
                 directory == root || directory.startsWith("$root/")

--- a/app/src/test/kotlin/dev/minios/ocremote/ui/screens/sessions/SessionProjectGroupingTest.kt
+++ b/app/src/test/kotlin/dev/minios/ocremote/ui/screens/sessions/SessionProjectGroupingTest.kt
@@ -58,6 +58,86 @@ class SessionProjectGroupingTest {
     }
 
     @Test
+    fun globalSessionWithKnownProjectDirectoryGroupsByProject() {
+        val projects = listOf(
+            Project(id = "global", worktree = "/", name = "Global"),
+            Project(id = "project-a", worktree = "/home/user/projects/foo", name = "Foo"),
+        )
+
+        val group = buildProjectSessionGroups(
+            listOf(item("session", "/home/user/projects/foo", projectId = "global")),
+            projects,
+            "/home/user",
+            emptyMap(),
+            "server",
+        ).single()
+
+        assertEquals("project-a", group.projectId)
+        assertEquals("Foo", group.projectName)
+    }
+
+    @Test
+    fun globalSessionsInUnknownDirectoriesBecomeSeparateGroups() {
+        val projects = listOf(
+            Project(id = "global", worktree = "/", name = "Global"),
+        )
+
+        val groups = buildProjectSessionGroups(
+            listOf(
+                item("one", "/srv/alpha", projectId = "global", updated = 2),
+                item("two", "/srv/beta", projectId = "global", updated = 1),
+            ),
+            projects,
+            null,
+            emptyMap(),
+            "server",
+        )
+
+        assertEquals(listOf("/srv/alpha", "/srv/beta"), groups.map { it.directory })
+        assertEquals(listOf("directory:/srv/alpha", "directory:/srv/beta"), groups.map { it.projectId })
+    }
+
+    @Test
+    fun globalSessionsPreferMostSpecificNonGlobalProjectOverGlobalRoot() {
+        val projects = listOf(
+            Project(id = "global", worktree = "/", name = "Global"),
+            Project(id = "repo", worktree = "/repo", name = "Root"),
+            Project(id = "nested", worktree = "/repo/apps/mobile", name = "Mobile"),
+        )
+
+        val group = buildProjectSessionGroups(
+            listOf(item("session", "/repo/apps/mobile/src", projectId = "global")),
+            projects,
+            null,
+            emptyMap(),
+            "server",
+        ).single()
+
+        assertEquals("nested", group.projectId)
+        assertEquals("Mobile", group.projectName)
+    }
+
+    @Test
+    fun nonGlobalProjectIdStillTakesPrecedenceOverDirectory() {
+        val projects = listOf(
+            Project(id = "project", worktree = "/repo", name = "Repository"),
+            Project(id = "other", worktree = "/elsewhere", name = "Elsewhere"),
+        )
+
+        val group = buildProjectSessionGroups(
+            listOf(item("session", "/elsewhere/nested", projectId = "project")),
+            projects,
+            null,
+            emptyMap(),
+            "server",
+        ).single()
+
+        assertEquals("project", group.projectId)
+        assertEquals("Repository", group.projectName)
+        assertEquals("/repo", group.directory)
+    }
+
+    @Test
     fun favoriteSessionsLeadAndRespectExplicitOrder() {
         val sorted = sortSessionItems(
             listOf(


### PR DESCRIPTION
## Problem

On OpenCode 1.18.x servers, sessions created from different project folders are all assigned `projectID: "global"`; the actual project is only recorded in `session.directory`.

In `buildProjectSessionGroups()`, `projectFor()` checked `session.projectId` against the project list *before* the directory fallback. The `global` project matched first (and often has a broad/root worktree), so every global session collapsed into a single group instead of being grouped per directory. Closes #34.

## Fix

Treat `projectId == "global"` as non-authoritative:

- Global sessions skip the explicit ID match and are matched against **non-global** project paths/worktrees only, keeping the existing longest-match behavior for nested paths (the Global project's root path can no longer capture them).
- Sessions with a real (non-global) project ID behave exactly as before.
- Global sessions in unknown directories fall through to the existing per-directory group keys, so separate directories become separate groups.

## Tests

4 regression tests added to `SessionProjectGroupingTest`:

- global session + directory matching a known real project → groups under that project
- two global sessions in unknown directories → separate groups
- nested matching prefers the most specific non-global project over the Global root
- non-global project IDs still take precedence over directory

Full unit suite: 211 tests, 0 failures.

Verified on-device against a live OpenCode server where 7 sessions from 5 different directories all reported `projectID: "global"` — they now group by their actual directories.